### PR TITLE
fix mongo uri in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,4 @@ services:
     depends_on:
       - mongodb
     environment:
-      - MONGO_URI=mongodb://mongodb:8101
+      - MONGO_URI=mongodb://mongodb:27017


### PR DESCRIPTION
Fix the server Mongo connection URI in docker-compose.yml to use the MongoDB container's internal port.

Changes:
updated MONGO_URI from mongodb://mongodb:8101 to mongodb://mongodb:27017