### PR TITLE
Add registration persistence models and Mongo lifecycle helpers

### DIFF
--- a/pkg/db/registration.go
+++ b/pkg/db/registration.go
@@ -1,0 +1,148 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/SCE-Development/SCEvents/pkg/registration"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func GetRegistrationsCollection() *mongo.Collection {
+	return Database().Collection("registrations")
+}
+
+// CreatePendingRegistration inserts a new registration request with status "pending" before async processing
+func CreatePendingRegistration(r registration.RegistrationRequest) (*registration.RegistrationRequest, error) {
+	coll := GetRegistrationsCollection()
+
+	now := time.Now().UTC()
+	r.Status = registration.StatusPending
+	r.DecisionReason = registration.ReasonNone
+	r.CreatedAt = now
+	r.UpdatedAt = now
+	r.ProcessedAt = nil
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := coll.InsertOne(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+// GetRegistrationByID fetches a registration request by its request_id
+func GetRegistrationByID(requestID string) (*registration.RegistrationRequest, error) {
+	coll := GetRegistrationsCollection()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var r registration.RegistrationRequest
+	err := coll.FindOne(ctx, bson.M{"_id": requestID}).Decode(&r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+// HasAcceptedRegistration checks if a user already has an accepted registration for an event
+func HasAcceptedRegistration(eventID string, userID string) (bool, error) {
+	coll := GetRegistrationsCollection()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	filter := bson.M{
+		"event_id":           eventID,
+		"registrant.user_id": userID,
+		"status":             registration.StatusAccepted,
+	}
+
+	err := coll.FindOne(ctx, filter).Err()
+	if err == mongo.ErrNoDocuments {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// MarkRegistrationAccepted transitions a pending request to accepted and records processing time
+func MarkRegistrationAccepted(requestID string) error {
+	coll := GetRegistrationsCollection()
+
+	now := time.Now().UTC()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	update := bson.M{
+		"$set": bson.M{
+			"status":          registration.StatusAccepted,
+			"decision_reason": registration.ReasonNone,
+			"updated_at":      now,
+			"processed_at":    now,
+		},
+	}
+
+	result, err := coll.UpdateOne(
+		ctx,
+		bson.M{
+			"_id":    requestID,
+			"status": registration.StatusPending,
+		},
+		update,
+	)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+
+	return nil
+}
+
+// MarkRegistrationRejected transitions a pending request to rejected with a reason
+func MarkRegistrationRejected(requestID string, reason registration.DecisionReason) error {
+	coll := GetRegistrationsCollection()
+
+	now := time.Now().UTC()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	update := bson.M{
+		"$set": bson.M{
+			"status":          registration.StatusRejected,
+			"decision_reason": reason,
+			"updated_at":      now,
+			"processed_at":    now,
+		},
+	}
+
+	result, err := coll.UpdateOne(
+		ctx,
+		bson.M{
+			"_id":    requestID,
+			"status": registration.StatusPending,
+		},
+		update,
+	)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+
+	return nil
+}

--- a/pkg/registration/registration.go
+++ b/pkg/registration/registration.go
@@ -1,0 +1,56 @@
+package registration
+
+import "time"
+
+type Status string
+type DecisionReason string
+
+const (
+	StatusPending  Status = "pending"
+	StatusAccepted Status = "accepted"
+	StatusRejected Status = "rejected"
+)
+
+const (
+	ReasonNone             DecisionReason = ""
+	ReasonEventNotFound    DecisionReason = "event_not_found"
+	ReasonDuplicateUser    DecisionReason = "duplicate_user"
+	ReasonCapacityFull     DecisionReason = "capacity_full"
+	ReasonInvalidPayload   DecisionReason = "invalid_payload"
+	ReasonAlreadyProcessed DecisionReason = "already_processed"
+	ReasonInternalError    DecisionReason = "internal_error"
+)
+
+type Registrant struct {
+	Name   string `bson:"name" json:"name" binding:"required"`
+	Email  string `bson:"email" json:"email" binding:"required,email"`
+	UserID string `bson:"user_id" json:"user_id"`
+}
+
+// SubmitRegistrationRequest represents the incoming API payload from the frontend when a user registers for an event
+type SubmitRegistrationRequest struct {
+	Registrant  Registrant     `bson:"registrant" json:"registrant" binding:"required"`
+	Answers     map[string]any `bson:"answers" json:"answers" binding:"required"`
+	SubmittedAt string         `bson:"submitted_at,omitempty" json:"submitted_at,omitempty"`
+}
+
+// RegistrationRequest is the source-of-truth document representing a user's registration lifecycle (pending to accepted/rejected)
+type RegistrationRequest struct {
+	RequestID      string         `bson:"_id" json:"request_id"`
+	EventID        string         `bson:"event_id" json:"event_id"`
+	Registrant     Registrant     `bson:"registrant" json:"registrant"`
+	Answers        map[string]any `bson:"answers" json:"answers"`
+	Status         Status         `bson:"status" json:"status"`
+	DecisionReason DecisionReason `bson:"decision_reason,omitempty" json:"decision_reason,omitempty"`
+	CreatedAt      time.Time      `bson:"created_at" json:"created_at"`
+	UpdatedAt      time.Time      `bson:"updated_at" json:"updated_at"`
+	ProcessedAt    *time.Time     `bson:"processed_at,omitempty" json:"processed_at,omitempty"`
+}
+
+// KafkaRegistrationMessage is a lightweight reference payload used by the consumer to process a registration request
+type KafkaRegistrationMessage struct {
+	RequestID string    `json:"request_id"`
+	EventID   string    `json:"event_id"`
+	UserID    string    `json:"user_id"`
+	CreatedAt time.Time `json:"created_at"`
+}


### PR DESCRIPTION
## Summary
Adds the registration persistence layer for async event registration processing.

## Changes
- add `pkg/registration/registration.go`
  - registration status and decision reason types
  - submit request model
  - persisted registration request model
  - Kafka registration message model
- add `pkg/db/registration.go`
  - create pending registration
  - get registration by ID
  - check for existing accepted registration
  - mark registration accepted
  - mark registration rejected

## Validation
- ran `gofmt`
- ran `go build ./...`
- ran `go test ./...`

## Notes
- This PR only covers the data model + persistence side.
- Consumer (Kafka processing) logic will be added in a follow-up PR