### PR TITLE
Fix event package name from types to event

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -1,4 +1,4 @@
-package types
+package event
 
 type AnswerDetails struct {
 	MaxChars int `bson:"max_chars,omitempty" json:"max_chars,omitempty"`

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
-	types "github.com/SCE-Development/SCEvents/pkg/event"
+	event "github.com/SCE-Development/SCEvents/pkg/event"
 	"github.com/gin-gonic/gin"
 )
 
@@ -37,7 +37,7 @@ func GetEventByID(c *gin.Context) {
 
 // creates a new event
 func CreateEvent(c *gin.Context) {
-	var event types.Event
+	var event event.Event
 
 	// parse JSON request body into struct
 	if err := c.BindJSON(&event); err != nil {
@@ -81,5 +81,3 @@ func DeleteEventByID(c *gin.Context) {
 		"message": "event deleted successfully",
 	})
 }
-
-


### PR DESCRIPTION
## Summary
Updates the `pkg/event` package name from `types` to `event` for consistency with imports and usage across the codebase.

## Changes
- rename package declaration in `pkg/event/event.go`
- update handler usage to reference `event.Event`

## Validation
- ran `gofmt`
- ran `go build ./...`
- ran `go test ./...`