### PR TITLE
Add Kafka consumer and Redis seat reservation flow

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"os"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
 	"github.com/SCE-Development/SCEvents/pkg/handlers"
+	"github.com/SCE-Development/SCEvents/pkg/registration"
 )
 
 const clientURL = "http://localhost:3000"
@@ -36,6 +38,21 @@ func main() {
 		}
 	}()
 
+	kafkaBroker := os.Getenv("KAFKA_BROKER")
+	kafkaTopic := os.Getenv("KAFKA_TOPIC")
+	kafkaGroupID := os.Getenv("KAFKA_GROUP_ID")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	consumer := registration.NewConsumer(
+		[]string{kafkaBroker},
+		kafkaTopic,
+		kafkaGroupID,
+	)
+	
+	go consumer.Run(ctx)
+	
 	r := gin.Default()
 
 	config := cors.DefaultConfig()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
     environment:
       - MONGO_URI=mongodb://mongodb:27017
       - REDIS_ADDR=redis:6379
+      - KAFKA_BROKER=kafka:29092
+      - KAFKA_TOPIC=registrations
+      - KAFKA_GROUP_ID=registration-consumers
 
   kafka:
     image: apache/kafka:3.8.0

--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/segmentio/kafka-go v0.4.50 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
+github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -91,6 +93,8 @@ github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/segmentio/kafka-go v0.4.50 h1:mcyC3tT5WeyWzrFbd6O374t+hmcu1NKt2Pu1L3QaXmc=
+github.com/segmentio/kafka-go v0.4.50/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/pkg/db/redis.go
+++ b/pkg/db/redis.go
@@ -78,3 +78,57 @@ func GetEventHeadcount(eventID string) (int, error) {
 	}
 	return val, nil
 }
+
+var takeSeatScript = redis.NewScript(`
+local current = redis.call("GET", KEYS[1])
+if not current then
+	return -2
+end
+
+current = tonumber(current)
+if current <= 0 then
+	return 0
+end
+
+redis.call("DECR", KEYS[1])
+return 1
+`)
+
+// TryTakeEventSeat atomically checks whether the event has remaining capacity
+// and decrements it by 1 only if capacity is available.
+func TryTakeEventSeat(eventID string) (bool, error) {
+	if redisClient == nil {
+		return false, fmt.Errorf("redis not connected")
+	}
+
+	ctx := context.Background()
+	key := EventHeadcountKey(eventID)
+
+	result, err := takeSeatScript.Run(ctx, redisClient, []string{key}).Int()
+	if err != nil {
+		return false, err
+	}
+
+	switch result {
+	case 1:
+		return true, nil
+	case 0:
+		return false, nil
+	case -2:
+		return false, fmt.Errorf("missing Redis headcount for event %s", eventID)
+	default:
+		return false, fmt.Errorf("unexpected Redis script result: %d", result)
+	}
+}
+
+// ReleaseEventSeat adds 1 back to the remaining capacity.
+func ReleaseEventSeat(eventID string) error {
+	if redisClient == nil {
+		return fmt.Errorf("redis not connected")
+	}
+
+	ctx := context.Background()
+	key := EventHeadcountKey(eventID)
+
+	return redisClient.Incr(ctx, key).Err()
+}

--- a/pkg/registration/consumer.go
+++ b/pkg/registration/consumer.go
@@ -1,0 +1,113 @@
+package registration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+
+	"github.com/SCE-Development/SCEvents/pkg/db"
+	"github.com/segmentio/kafka-go"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type Consumer struct {
+	reader *kafka.Reader
+}
+
+func NewConsumer(brokers []string, topic string, groupID string) *Consumer {
+	r := kafka.NewReader(kafka.ReaderConfig{
+		Brokers:        brokers,
+		Topic:          topic,
+		GroupID:        groupID,
+		CommitInterval: 0,
+	})
+
+	return &Consumer{reader: r}
+}
+
+func (c *Consumer) Run(ctx context.Context) {
+	for {
+		msg, err := c.reader.FetchMessage(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Printf("consumer fetch error: %v", err)
+			continue
+		}
+
+		if err := ProcessKafkaMessage(msg.Value); err != nil {
+			log.Printf("consumer process error: %v", err)
+			continue
+		}
+
+		if err := c.reader.CommitMessages(ctx, msg); err != nil {
+			log.Printf("consumer commit error: %v", err)
+		}
+	}
+}
+
+func ProcessKafkaMessage(raw []byte) error {
+	var msg KafkaRegistrationMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return err
+	}
+
+	if err := validateKafkaMessage(msg); err != nil {
+		return err
+	}
+
+	req, err := db.GetRegistrationByID(msg.RequestID)
+	if err != nil {
+		return err
+	}
+
+	if req.Status != StatusPending {
+		return nil
+	}
+
+	_, err = db.GetEventByID(msg.EventID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return db.MarkRegistrationRejected(msg.RequestID, ReasonEventNotFound)
+		}
+		return err
+	}
+
+	duplicate, err := db.HasAcceptedRegistration(msg.EventID, msg.UserID)
+	if err != nil {
+		return err
+	}
+	if duplicate {
+		return db.MarkRegistrationRejected(msg.RequestID, ReasonDuplicateUser)
+	}
+
+	ok, err := db.TryTakeEventSeat(msg.EventID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return db.MarkRegistrationRejected(msg.RequestID, ReasonCapacityFull)
+	}
+
+	if err := db.MarkRegistrationAccepted(msg.RequestID); err != nil {
+		_ = db.ReleaseEventSeat(msg.EventID)
+		return err
+	}
+
+	return nil
+}
+
+func validateKafkaMessage(msg KafkaRegistrationMessage) error {
+	if msg.RequestID == "" {
+		return errors.New("missing request_id")
+	}
+	if msg.EventID == "" {
+		return errors.New("missing event_id")
+	}
+	if msg.UserID == "" {
+		return errors.New("missing user_id")
+	}
+	return nil
+}


### PR DESCRIPTION
### Description
This PR adds the consumer-side registration processing pipeline for event registrations.

### What this PR does
- adds a Kafka consumer that continuously reads registration messages from the configured topic
- deserializes Kafka messages into KafkaRegistrationMessage
- validates required consumed fields:
- request_id
- event_id
- user_id
- fetches the corresponding pending registration request from MongoDB
- processes the registration in this order:
1. ensure request is still pending
2. ensure event exists
3. check whether the user already has an accepted registration
4. atomically reserve a seat in Redis
5. mark registration as accepted or rejected in MongoDB
- adds Redis seat reservation helpers:
- TryTakeEventSeat
- ReleaseEventSeat