### PR TITLE
Add centralized config loader for server settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN go mod download
 
 COPY cmd/ cmd/
 COPY pkg/ pkg/
+COPY internal/ internal/
 RUN go build -o ./scevents ./cmd/server
 
 # production stage

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,21 +4,20 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 
+	"github.com/SCE-Development/SCEvents/internal/config"
 	"github.com/SCE-Development/SCEvents/pkg/db"
 	"github.com/SCE-Development/SCEvents/pkg/handlers"
 	"github.com/SCE-Development/SCEvents/pkg/registration"
 )
 
-const clientURL = "http://localhost:3000"
-
 func main() {
-	mongoURI := os.Getenv("MONGO_URI")
-	if err := db.Connect(mongoURI); err != nil {
+	cfg := config.Load()
+
+	if err := db.Connect(cfg.MongoURI); err != nil {
 		log.Fatalf("Failed to connect to MongoDB: %v", err)
 	}
 	defer func() {
@@ -27,9 +26,7 @@ func main() {
 		}
 	}()
 
-	// Get Redis address from environment variable
-	redisAddr := os.Getenv("REDIS_ADDR")
-	if err := db.ConnectRedis(redisAddr); err != nil {
+	if err := db.ConnectRedis(cfg.RedisAddr); err != nil {
 		log.Fatalf("Failed to connect to Redis: %v", err)
 	}
 	defer func(){
@@ -38,17 +35,13 @@ func main() {
 		}
 	}()
 
-	kafkaBroker := os.Getenv("KAFKA_BROKER")
-	kafkaTopic := os.Getenv("KAFKA_TOPIC")
-	kafkaGroupID := os.Getenv("KAFKA_GROUP_ID")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	consumer := registration.NewConsumer(
-		[]string{kafkaBroker},
-		kafkaTopic,
-		kafkaGroupID,
+		[]string{cfg.KafkaBroker},
+		cfg.KafkaTopic,
+		cfg.KafkaGroupID,
 	)
 	
 	go consumer.Run(ctx)
@@ -56,7 +49,7 @@ func main() {
 	r := gin.Default()
 
 	config := cors.DefaultConfig()
-	config.AllowOrigins = []string{clientURL}
+	config.AllowOrigins = []string{cfg.ClientURL}
 	config.AllowCredentials = true
 	config.AddAllowHeaders("Authorization")
 	r.Use(cors.New(config))
@@ -77,5 +70,7 @@ func main() {
 		events.PATCH("/:id", handlers.UpdateEventByID)
 	}
 
-	r.Run(":8002")
+	if err := r.Run(":" + cfg.ServerPort); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,18 +25,18 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8002:8002"
+      - "${SERVER_PORT:-8002}:${SERVER_PORT:-8002}"
     depends_on:
       - mongodb
       - redis
     environment:
-      - MONGO_URI=mongodb://mongodb:27017
-      - REDIS_ADDR=redis:6379
-      - KAFKA_BROKER=kafka:29092
-      - KAFKA_TOPIC=registrations
-      - KAFKA_GROUP_ID=registration-consumers
-      - SERVER_PORT=8002
-      - CLIENT_URL=http://localhost:3000
+      - MONGO_URI=${MONGO_URI:-mongodb://mongodb:27017}
+      - REDIS_ADDR=${REDIS_ADDR:-redis:6379}
+      - KAFKA_BROKER=${KAFKA_BROKER:-kafka:29092}
+      - KAFKA_TOPIC=${KAFKA_TOPIC:-registrations}
+      - KAFKA_GROUP_ID=${KAFKA_GROUP_ID:-registration-consumers}
+      - SERVER_PORT=${SERVER_PORT:-8002}
+      - CLIENT_URL=${CLIENT_URL:-http://localhost:3000}
 
   kafka:
     image: apache/kafka:3.8.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       - KAFKA_BROKER=kafka:29092
       - KAFKA_TOPIC=registrations
       - KAFKA_GROUP_ID=registration-consumers
+      - SERVER_PORT=8002
+      - CLIENT_URL=http://localhost:3000
 
   kafka:
     image: apache/kafka:3.8.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,33 @@
+package config
+
+import "os"
+
+type AppConfig struct {
+	MongoURI     string
+	RedisAddr    string
+	KafkaBroker  string
+	KafkaTopic   string
+	KafkaGroupID string
+	ServerPort   string
+	ClientURL    string
+}
+
+func Load() AppConfig {
+	return AppConfig{
+		MongoURI:     getEnv("MONGO_URI", "mongodb://localhost:27017"),
+		RedisAddr:    getEnv("REDIS_ADDR", "localhost:6379"),
+		KafkaBroker:  getEnv("KAFKA_BROKER", "localhost:9092"),
+		KafkaTopic:   getEnv("KAFKA_TOPIC", "registrations"),
+		KafkaGroupID: getEnv("KAFKA_GROUP_ID", "registration-consumers"),
+		ServerPort:   getEnv("SERVER_PORT", "8002"),
+		ClientURL:    getEnv("CLIENT_URL", "http://localhost:3000"),
+	}
+}
+
+func getEnv(key string, fallback string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	return value
+}


### PR DESCRIPTION
#32 
- added centralized config loader in internal/config/config.go
- moved environment variable loading out of main.go
- made server port configurable through SERVER_PORT
- updated docker-compose.yml to pass the new port environment variable