### PR TITLE
Created mongo registration requests functions

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,6 +35,20 @@ func main() {
 		}
 	}()
 
+	kafkaBroker := os.Getenv("KAFKA_BROKER")
+	kafkaTopic := os.Getenv("KAFKA_TOPIC")
+	kafkaGroupID := os.Getenv("KAFKA_GROUP_ID")
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+	if kafkaBroker == "" || kafkaTopic == "" {
+		log.Println("warning: KAFKA_BROKER or KAFKA_TOPIC empty")
+	}
+
+>>>>>>> c493044 (Removed kafka implementation stuff)
+=======
+>>>>>>> 0e55751 (Removing code based off Steven's comments)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -66,6 +80,7 @@ func main() {
 		events.GET("/:id", handlers.GetEventByID)
 		events.POST("/", handlers.CreateEvent)
 		events.POST("/:id/register", handlers.RegisterForEvent)
+		events.GET("/registrations/:request_id", handlers.GetRegistrationStatus)
 		events.DELETE("/:id", handlers.DeleteEventByID)
 		events.PATCH("/:id", handlers.UpdateEventByID)
 	}

--- a/pkg/db/registration.go
+++ b/pkg/db/registration.go
@@ -75,6 +75,33 @@ func HasAcceptedRegistration(eventID string, userID string) (bool, error) {
 	return true, nil
 }
 
+// HasPendingOrAcceptedRegistration checks if a user has an in-flight or accepted registration for an event.
+// This is used to make the HTTP registration endpoint idempotent-ish for double submits.
+func HasPendingOrAcceptedRegistration(eventID string, userID string) (bool, error) {
+	coll := GetRegistrationsCollection()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	filter := bson.M{
+		"event_id":           eventID,
+		"registrant.user_id": userID,
+		"status": bson.M{
+			"$in": []models.Status{models.StatusPending, models.StatusAccepted},
+		},
+	}
+
+	err := coll.FindOne(ctx, filter).Err()
+	if err == mongo.ErrNoDocuments {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 // MarkRegistrationAccepted transitions a pending request to accepted and records processing time
 func MarkRegistrationAccepted(requestID string) error {
 	coll := GetRegistrationsCollection()

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -1,10 +1,11 @@
 package handlers
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
 	"github.com/SCE-Development/SCEvents/pkg/models"
@@ -277,7 +278,7 @@ func RegisterForEvent(c *gin.Context) {
 		return
 	}
 
-	alreadyRegistered, err := db.IsUserRegisteredForEvent(eventID, payload.Registrant.UserID)
+	alreadyRegistered, err := db.HasPendingOrAcceptedRegistration(eventID, payload.Registrant.UserID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "failed to verify existing registration",
@@ -314,8 +315,82 @@ func RegisterForEvent(c *gin.Context) {
 		return
 	}
 
+	var requestIDBytes [16]byte
+	if _, err := rand.Read(requestIDBytes[:]); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to create registration request",
+		})
+		return
+	}
+	requestID := hex.EncodeToString(requestIDBytes[:])
+
+	mongoRequest := models.RegistrationRequest{
+		RequestID:  requestID,
+		EventID:    eventID,
+		Registrant: payload.Registrant,
+		Answers:    payload.RegistrationFormAnswers,
+	}
+
+	_, err = db.CreatePendingRegistration(mongoRequest)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to persist registration request",
+		})
+		return
+	}
+
 	c.JSON(http.StatusAccepted, gin.H{
-		"message":  "registration request sent",
-		"event_id": eventID,
+		"message":    "registration request sent",
+		"event_id":   eventID,
+		"request_id": requestID,
+	})
+}
+
+func GetRegistrationStatus(c *gin.Context) {
+	requestID := c.Param("request_id")
+	if strings.TrimSpace(requestID) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "request id is required",
+		})
+		return
+	}
+
+	userID := c.Query("user_id")
+	if strings.TrimSpace(userID) == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "missing user_id query parameter",
+		})
+		return
+	}
+
+	req, err := db.GetRegistrationByID(requestID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "registration request not found",
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch registration status",
+		})
+		return
+	}
+
+	if req.Registrant.UserID != userID {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "you do not have access to this registration request",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"request_id":      req.RequestID,
+		"event_id":        req.EventID,
+		"status":          req.Status,
+		"decision_reason": req.DecisionReason,
+		"created_at":      req.CreatedAt,
+		"updated_at":      req.UpdatedAt,
+		"processed_at":    req.ProcessedAt,
 	})
 }


### PR DESCRIPTION
This PR is for issue #34 which is creating write registration to MongoDB. The code will take registration payloads and write them to MongoDB.

## Changes made
- RegisterForEvent updated to create and save a RegistrationRequest that will be written to MongoDB
- GetRegistrationStatus was added to allow for polling of a user's registration, basically live status of whether they registered or not (see below image)
- Created the Kafka send off function for the producer (producer code doesn't currently exist)
- registration.go uses multiple resources like publish_state and publish_attempts for automatic retrying of registration
- HasPendingOrAcceptedRegistration was added to prevent users from sending many requests, users will instead see an unclickable button (see below image)

## Images

<img width="752" height="750" alt="Screenshot 2026-04-14 at 12 16 17 AM" src="https://github.com/user-attachments/assets/6cc74a33-68ce-4fbd-9b26-4ad45109362b" />
<img width="1201" height="114" alt="Screenshot 2026-04-14 at 12 16 43 AM" src="https://github.com/user-attachments/assets/b851d0ad-d412-4227-a751-e1fb0d1f3d40" />

## Things to note
- For testing, I had to make some changes to the front end to call my new functions. These changes have not been committed or had a PR in Clark.
- For SCEvents, I had to create a dummy producer.go file inside the pkg/registration folder. This file was not included in this commit and PR.