### PR TITLE
Fix empty event _id generation in CreateEvent

### DIFF
--- a/pkg/db/event.go
+++ b/pkg/db/event.go
@@ -74,19 +74,13 @@ func CreateEvent(e models.Event) (*models.Event, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	res, err := coll.InsertOne(ctx, e)
-	if err != nil {
-		return nil, err
+	if e.ID == "" {
+		e.ID = primitive.NewObjectID().Hex()
 	}
 
-	// if Mongo generated an ID, reflect it back in the event
-	if e.ID == "" {
-		switch id := res.InsertedID.(type) {
-		case primitive.ObjectID:
-			e.ID = id.Hex()
-		case string:
-			e.ID = id
-		}
+	_, err := coll.InsertOne(ctx, e)
+	if err != nil {
+		return nil, err
 	}
 
 	return &e, nil


### PR DESCRIPTION
Closes #49

## Summary
Ensure that new events are created with a valid non-empty `_id`.

## Fix
Generate a string ID (`primitive.ObjectID().Hex()`) before calling `InsertOne()` when `e.ID` is empty.

## Verification
Example terminal result after fix:

```bash
curl -X POST http://localhost:8002/events/ \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test Event With Status",
    "date": "2026-04-20",
    "time": "18:00",
    "location": "Student Union",
    "description": "Manual status test",
    "admins": ["user123"],
    "registration_form": [],
    "max_attendees": 50,
    "status": "draft"
  }'
```

```json
{"id":"69ddefd15aeab4a1f0851d92","name":"Test Event With Status","date":"2026-04-20","time":"18:00","location":"Student Union","description":"Manual status test","admins":["user123"],"registration_form":[],"max_attendees":50,"created_at":"","status":"draft"}
```

Previously, events could be inserted with an empty string `_id`, which caused later create/update operations to fail.