### PR TITLE
Add simple Go CI workflow

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,4 +1,4 @@
-name: Go CI
+name: Golang Validation
 
 on:
   pull_request:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,33 @@
+name: Go CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  verify-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Verify dependencies are synced
+        run: |
+          go mod tidy
+          go mod vendor
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Build all packages
+        run: go build ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /data
 .DS_Store
+/vendor


### PR DESCRIPTION
- added a simple GitHub Actions workflow for Go CI
- verifies go.mod and go.sum stay in sync after go mod tidy
- builds all packages with go build ./...
- ignores vendor/ since the repo is not tracking vendored dependencies
Closes #46