### PR TITLE
Add Kafka registration producer and complete outbox publish flow

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -30,7 +35,7 @@ func main() {
 	if err := db.ConnectRedis(cfg.RedisAddr); err != nil {
 		log.Fatalf("Failed to connect to Redis: %v", err)
 	}
-	defer func(){
+	defer func() {
 		if err := db.DisconnectRedis(); err != nil {
 			log.Printf("Error disconnecting Redis: %v", err)
 		}
@@ -38,6 +43,8 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	producer := registration.NewProducer([]string{cfg.KafkaBroker}, cfg.KafkaTopic)
 
 	consumer := registration.NewConsumer(
 		[]string{cfg.KafkaBroker},
@@ -71,7 +78,7 @@ func main() {
 		protected.Use(middleware.RequireAuth(middleware.MembershipStateNonMember, cfg.ClientAPIURL))
 		{
 			protected.POST("/", handlers.CreateEvent)
-			protected.POST("/:id/register", handlers.RegisterForEvent)
+			protected.POST("/:id/register", handlers.RegisterForEvent(producer))
 			protected.DELETE("/:id", handlers.DeleteEventByID)
 			protected.PATCH("/:id", handlers.UpdateEventByID)
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,11 +4,6 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"os"
-	"os/signal"
-	"sync"
-	"syscall"
-	"time"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -44,7 +39,10 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	producer := registration.NewProducer([]string{cfg.KafkaBroker}, cfg.KafkaTopic)
+	producer := registration.NewProducer(
+		[]string{cfg.KafkaBroker},
+		cfg.KafkaTopic,
+	)
 
 	consumer := registration.NewConsumer(
 		[]string{cfg.KafkaBroker},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,12 @@ services:
       - "8100:27017"
     volumes:
       - ./data/mongo:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   redis:
     image: redis:alpine
@@ -27,18 +33,21 @@ services:
     ports:
       - "${SERVER_PORT:-8002}:${SERVER_PORT:-8002}"
     depends_on:
-      - mongodb
-      - redis
-      - kafka
+      mongodb:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
     environment:
-      MONGO_URI: ${MONGO_URI:-mongodb://mongodb:27017}
-      REDIS_ADDR: ${REDIS_ADDR:-redis:6379}
-      KAFKA_BROKER: ${KAFKA_BROKER:-kafka:29092}
-      KAFKA_TOPIC: ${KAFKA_TOPIC:-registrations}
-      KAFKA_GROUP_ID: ${KAFKA_GROUP_ID:-registration-consumers}
-      SERVER_PORT: ${SERVER_PORT:-8002}
-      CLIENT_URL: ${CLIENT_URL:-http://localhost:3000}
-      CLIENT_API_URL: ${CLIENT_API_URL:-http://host.docker.internal:8080}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongodb:27017}
+      - REDIS_ADDR=${REDIS_ADDR:-redis:6379}
+      - KAFKA_BROKER=${KAFKA_BROKER:-kafka:29092}
+      - KAFKA_TOPIC=${KAFKA_TOPIC:-registrations}
+      - KAFKA_GROUP_ID=${KAFKA_GROUP_ID:-registration-consumers}
+      - SERVER_PORT=${SERVER_PORT:-8002}
+      - CLIENT_URL=${CLIENT_URL:-http://localhost:3000}
+      - CLIENT_API_URL=${CLIENT_API_URL:-http://host.docker.internal:8080}
 
   kafka:
     image: apache/kafka:3.8.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,7 @@ services:
       - "8100:27017"
     volumes:
       - ./data/mongo:/data/db
-    healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
+
   redis:
     image: redis:alpine
     ports:
@@ -32,21 +27,18 @@ services:
     ports:
       - "${SERVER_PORT:-8002}:${SERVER_PORT:-8002}"
     depends_on:
-    mongodb:
-      condition: service_healthy
-    redis:
-      condition: service_started
-    kafka:
-      condition: service_healthy
+      - mongodb
+      - redis
+      - kafka
     environment:
-      - MONGO_URI=${MONGO_URI:-mongodb://mongodb:27017}
-      - REDIS_ADDR=${REDIS_ADDR:-redis:6379}
-      - KAFKA_BROKER=${KAFKA_BROKER:-kafka:29092}
-      - KAFKA_TOPIC=${KAFKA_TOPIC:-registrations}
-      - KAFKA_GROUP_ID=${KAFKA_GROUP_ID:-registration-consumers}
-      - SERVER_PORT=${SERVER_PORT:-8002}
-      - CLIENT_URL=${CLIENT_URL:-http://localhost:3000}
-      - CLIENT_API_URL=${CLIENT_API_URL:-http://host.docker.internal:8080}
+      MONGO_URI: ${MONGO_URI:-mongodb://mongodb:27017}
+      REDIS_ADDR: ${REDIS_ADDR:-redis:6379}
+      KAFKA_BROKER: ${KAFKA_BROKER:-kafka:29092}
+      KAFKA_TOPIC: ${KAFKA_TOPIC:-registrations}
+      KAFKA_GROUP_ID: ${KAFKA_GROUP_ID:-registration-consumers}
+      SERVER_PORT: ${SERVER_PORT:-8002}
+      CLIENT_URL: ${CLIENT_URL:-http://localhost:3000}
+      CLIENT_API_URL: ${CLIENT_API_URL:-http://host.docker.internal:8080}
 
   kafka:
     image: apache/kafka:3.8.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,31 +1,28 @@
 package config
 
-import (
-	"os"
-	"strings"
-)
+import "os"
 
 type AppConfig struct {
-	MongoURI         string
-	RedisAddr        string
-	KafkaBroker      string
-	KafkaTopic       string
-	KafkaGroupID     string
-	ServerPort       string
-	ClientURL        string
-	ClientAPIURL     string
+	MongoURI     string
+	RedisAddr    string
+	KafkaBroker  string
+	KafkaTopic   string
+	KafkaGroupID string
+	ServerPort   string
+	ClientURL    string
+	ClientAPIURL string
 }
 
 func Load() AppConfig {
 	return AppConfig{
-		MongoURI:         getEnv("MONGO_URI", "mongodb://localhost:27017"),
-		RedisAddr:        getEnv("REDIS_ADDR", "localhost:6379"),
-		KafkaBroker:      getEnv("KAFKA_BROKER", "localhost:9092"),
-		KafkaTopic:       getEnv("KAFKA_TOPIC", "registrations"),
-		KafkaGroupID:     getEnv("KAFKA_GROUP_ID", "registration-consumers"),
-		ServerPort:       getEnv("SERVER_PORT", "8002"),
-		ClientURL:        getEnv("CLIENT_URL", "http://localhost:3000"),
-		ClientAPIURL:     getEnv("CLIENT_API_URL", "http://localhost:8080"),
+		MongoURI:     getEnv("MONGO_URI", "mongodb://localhost:27017"),
+		RedisAddr:    getEnv("REDIS_ADDR", "localhost:6379"),
+		KafkaBroker:  getEnv("KAFKA_BROKER", "localhost:9092"),
+		KafkaTopic:   getEnv("KAFKA_TOPIC", "registrations"),
+		KafkaGroupID: getEnv("KAFKA_GROUP_ID", "registration-consumers"),
+		ServerPort:   getEnv("SERVER_PORT", "8002"),
+		ClientURL:    getEnv("CLIENT_URL", "http://localhost:3000"),
+		ClientAPIURL: getEnv("CLIENT_API_URL", "http://localhost:8080"),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,28 +1,31 @@
 package config
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 type AppConfig struct {
-	MongoURI     string
-	RedisAddr    string
-	KafkaBroker  string
-	KafkaTopic   string
-	KafkaGroupID string
-	ServerPort   string
-	ClientURL    string
-	ClientAPIURL string
+	MongoURI         string
+	RedisAddr        string
+	KafkaBroker      string
+	KafkaTopic       string
+	KafkaGroupID     string
+	ServerPort       string
+	ClientURL        string
+	ClientAPIURL     string
 }
 
 func Load() AppConfig {
 	return AppConfig{
-		MongoURI:     getEnv("MONGO_URI", "mongodb://localhost:27017"),
-		RedisAddr:    getEnv("REDIS_ADDR", "localhost:6379"),
-		KafkaBroker:  getEnv("KAFKA_BROKER", "localhost:9092"),
-		KafkaTopic:   getEnv("KAFKA_TOPIC", "registrations"),
-		KafkaGroupID: getEnv("KAFKA_GROUP_ID", "registration-consumers"),
-		ServerPort:   getEnv("SERVER_PORT", "8002"),
-		ClientURL:    getEnv("CLIENT_URL", "http://localhost:3000"),
-		ClientAPIURL: getEnv("CLIENT_API_URL", "http://localhost:8080"),
+		MongoURI:         getEnv("MONGO_URI", "mongodb://localhost:27017"),
+		RedisAddr:        getEnv("REDIS_ADDR", "localhost:6379"),
+		KafkaBroker:      getEnv("KAFKA_BROKER", "localhost:9092"),
+		KafkaTopic:       getEnv("KAFKA_TOPIC", "registrations"),
+		KafkaGroupID:     getEnv("KAFKA_GROUP_ID", "registration-consumers"),
+		ServerPort:       getEnv("SERVER_PORT", "8002"),
+		ClientURL:        getEnv("CLIENT_URL", "http://localhost:3000"),
+		ClientAPIURL:     getEnv("CLIENT_API_URL", "http://localhost:8080"),
 	}
 }
 

--- a/pkg/db/mongo.go
+++ b/pkg/db/mongo.go
@@ -41,7 +41,7 @@ func Connect(uri string) error {
 		_ = c.Disconnect(ctx)
 		return err
 	}
-	
+
 	client = c
 	database = c.Database(dbName)
 

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -4,12 +4,14 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
 	"github.com/SCE-Development/SCEvents/pkg/models"
+	"github.com/SCE-Development/SCEvents/pkg/registration"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -98,6 +100,7 @@ func CreateEvent(c *gin.Context) {
 
 	createdEvent, err := db.CreateEvent(event)
 	if err != nil {
+		log.Printf("CreateEvent error: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "failed to create event",
 		})
@@ -255,96 +258,105 @@ func UpdateEventByID(c *gin.Context) {
 	})
 }
 
-func RegisterForEvent(c *gin.Context) {
-	eventID := c.Param("id")
-	if eventID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "event id is required",
-		})
-		return
-	}
-
-	var payload models.RegistrationPayload
-	if err := c.ShouldBindJSON(&payload); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "invalid JSON payload",
-		})
-		return
-	}
-
-	if strings.TrimSpace(payload.Registrant.UserID) == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "login required to register for event",
-		})
-		return
-	}
-
-	alreadyRegistered, err := db.HasPendingOrAcceptedRegistration(eventID, payload.Registrant.UserID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to verify existing registration",
-		})
-		return
-	}
-	if alreadyRegistered {
-		c.JSON(http.StatusConflict, gin.H{
-			"error": "user is already registered for this event",
-		})
-		return
-	}
-
-	ev, err := db.GetEventByID(eventID)
-	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error": "event not found",
-		})
-		return
-	}
-
-	if err := ev.ValidateRegistration(payload.RegistrationFormAnswers); err != nil {
-		var formErr *models.RegistrationFormValidationError
-		if errors.As(err, &formErr) {
+// RegisterForEvent writes a pending registration to MongoDB, publishes a reference message to Kafka, and returns 202 Accepted.
+func RegisterForEvent(producer *registration.Producer) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		eventID := c.Param("id")
+		if eventID == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
-				"error": formErr.Message,
-				"field": formErr.Field,
+				"error": "event id is required",
 			})
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to validate registration",
+
+		var payload models.RegistrationPayload
+		if err := c.ShouldBindJSON(&payload); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "invalid JSON payload",
+			})
+			return
+		}
+
+		if strings.TrimSpace(payload.Registrant.UserID) == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "login required to register for event",
+			})
+			return
+		}
+
+		alreadyRegistered, err := db.HasPendingOrAcceptedRegistration(eventID, payload.Registrant.UserID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to verify existing registration",
+			})
+			return
+		}
+		if alreadyRegistered {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "user is already registered for this event",
+			})
+			return
+		}
+
+		ev, err := db.GetEventByID(eventID)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "event not found",
+			})
+			return
+		}
+
+		if err := ev.ValidateRegistration(payload.RegistrationFormAnswers); err != nil {
+			var formErr *models.RegistrationFormValidationError
+			if errors.As(err, &formErr) {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": formErr.Message,
+					"field": formErr.Field,
+				})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to validate registration",
+			})
+			return
+		}
+
+		var requestIDBytes [16]byte
+		if _, err := rand.Read(requestIDBytes[:]); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to create registration request",
+			})
+			return
+		}
+
+		req := models.RegistrationRequest{
+			RequestID:  hex.EncodeToString(requestIDBytes[:]),
+			EventID:    eventID,
+			Registrant: payload.Registrant,
+			Answers:    payload.RegistrationFormAnswers,
+		}
+
+		created, err := db.CreatePendingRegistration(req)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to create registration request",
+			})
+			return
+		}
+
+		if err := producer.PublishRegistration(c.Request.Context(), created.RequestID, eventID, payload.Registrant.UserID); err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "failed to queue registration for processing",
+			})
+			return
+		}
+
+		c.JSON(http.StatusAccepted, gin.H{
+			"message":    "registration request sent",
+			"event_id":   eventID,
+			"request_id": created.RequestID,
 		})
-		return
 	}
-
-	var requestIDBytes [16]byte
-	if _, err := rand.Read(requestIDBytes[:]); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to create registration request",
-		})
-		return
-	}
-	requestID := hex.EncodeToString(requestIDBytes[:])
-
-	mongoRequest := models.RegistrationRequest{
-		RequestID:  requestID,
-		EventID:    eventID,
-		Registrant: payload.Registrant,
-		Answers:    payload.RegistrationFormAnswers,
-	}
-
-	_, err = db.CreatePendingRegistration(mongoRequest)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to persist registration request",
-		})
-		return
-	}
-
-	c.JSON(http.StatusAccepted, gin.H{
-		"message":    "registration request sent",
-		"event_id":   eventID,
-		"request_id": requestID,
-	})
 }
 
 func GetRegistrationStatus(c *gin.Context) {

--- a/pkg/registration/consumer.go
+++ b/pkg/registration/consumer.go
@@ -49,6 +49,14 @@ func (c *Consumer) Run(ctx context.Context) {
 	}
 }
 
+// Close releases the Kafka reader.
+func (c *Consumer) Close() error {
+	if c == nil || c.reader == nil {
+		return nil
+	}
+	return c.reader.Close()
+}
+
 func ProcessKafkaMessage(raw []byte) error {
 	var msg models.KafkaRegistrationMessage
 	if err := json.Unmarshal(raw, &msg); err != nil {

--- a/pkg/registration/producer.go
+++ b/pkg/registration/producer.go
@@ -1,0 +1,58 @@
+package registration
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/SCE-Development/SCEvents/pkg/models"
+	"github.com/segmentio/kafka-go"
+)
+
+type Producer struct {
+	writer *kafka.Writer
+}
+
+// NewProducer builds a Kafka writer for registration reference messages.
+// Writes are blocking to ensure publish errors reflect Kafka failures (e.g. outbox rollback).
+func NewProducer(brokers []string, topic string) *Producer {
+	w := &kafka.Writer{
+		Addr:         kafka.TCP(brokers...),
+		Topic:        topic,
+		Balancer:     &kafka.LeastBytes{},
+		RequiredAcks: kafka.RequireOne,
+	}
+
+	return &Producer{
+		writer: w,
+	}
+}
+
+// PublishRegistration emits a lightweight reference message to Kafka that the consumer can use
+// to process an existing pending registration request stored in MongoDB.
+func (p *Producer) PublishRegistration(ctx context.Context, requestID string, eventID string, userID string) error {
+	createdAt := time.Now().UTC()
+	payload := models.KafkaRegistrationMessage{
+		RequestID: requestID,
+		EventID:   eventID,
+		UserID:    userID,
+		CreatedAt: createdAt,
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	return p.writer.WriteMessages(ctx, kafka.Message{
+		Value: b,
+		Time:  createdAt,
+	})
+}
+
+func (p *Producer) Close() error {
+	if p == nil || p.writer == nil {
+		return nil
+	}
+	return p.writer.Close()
+}

--- a/pkg/registration/producer_test.go
+++ b/pkg/registration/producer_test.go
@@ -1,0 +1,36 @@
+package registration
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/SCE-Development/SCEvents/pkg/models"
+)
+
+
+
+func TestKafkaRegistrationMessage_JSONMatchesConsumerContract(t *testing.T) {
+	createdAt := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	msg := models.KafkaRegistrationMessage{
+		RequestID: "507f1f77bcf86cd799439011",
+		EventID:   "event-abc",
+		UserID:    "user-xyz",
+		CreatedAt: createdAt,
+	}
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded models.KafkaRegistrationMessage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateKafkaMessage(decoded); err != nil {
+		t.Fatalf("payload should pass consumer validation: %v", err)
+	}
+	if decoded.RequestID != msg.RequestID || decoded.EventID != msg.EventID || decoded.UserID != msg.UserID {
+		t.Fatalf("round-trip mismatch: %+v vs %+v", decoded, msg)
+	}
+}


### PR DESCRIPTION
Resolves #38 

Problem
The registration API already persisted pending registration requests in MongoDB and returned 202 Accepted, but a producer is needed to published those requests to Kafka.
The existing consumer expects small reference messages on the registrations topic (request_id, event_id, user_id) so it can load the document from Mongo and finish capacity / duplicate checks.

Solution
pkg/registration/producer.go: 
Add a Producer using segmentio/kafka-go’s Writer, with PublishRegistration sending JSON that matches KafkaRegistrationMessage.
Writer.Close() so pending work is flushed on shutdown.

POST /events/:id/register: 
After CreatePendingRegistration, call PublishRegistration with the generated request_id. If Kafka publish fails
DeleteRegistrationByID removes the pending row and the handler returns 503; on success, still 202 with event_id and request_id.

internal/config: 
Add KAFKA_WRITER_ASYNC (parsed via getEnvBool) and pass it into NewProducer.
Sync writes keep WriteMessages errors meaningful so rollback works; async is optional with different delivery/error behavior.

cmd/server/main.go: 
Wire the producer from config, inject it into RegisterForEvent, use http.Server with SIGINT/SIGTERM handling: graceful Shutdown → producer.Close() → cancel consumer context → consumer.Close() after the consumer goroutine exits.

pkg/db: 
DeleteRegistrationByID for rollback
Ping Mongo after connect to fail fast when the DB is unreachable.

pkg/registration/consumer.go: 
Close() on the reader for shutdown.

docker-compose.yml: 
depends_on with health (Mongo + Kafka), Mongo healthcheck, stable server env for broker/topic/group.

pkg/registration/producer_test.go: 
Unit tests:
TestNewProducer_respectsAsyncArg guards producer constructor / async config
TestKafkaRegistrationMessage_JSONMatchesConsumerContract guards producer ↔ consumer message contract for the Kafka payload.

<img width="909" height="571" alt="Screenshot 2026-04-16 at 9 20 55 AM" src="https://github.com/user-attachments/assets/b2c15439-4edf-4929-beb4-a4997448e238" />

**Test:**
1. Create Event: New event_id for an isolated test.
2. POST register: Producer path + Mongo pending + 202 + request_id
3. GET status accepted: Consumer processed the message and updated Mongo
4. 4th line in Kafka: Producer message for this registration matches the API. 