### PR TITLE
Support admin-less events 

### DIFF
--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -18,6 +18,18 @@ import (
 
 const dateLayout = "2006-01-02"
 
+func writeEventEditForbidden(c *gin.Context, ev *models.Event) {
+	if len(ev.Admins) == 0 {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "this event has no dedicated admins; only site admins may modify it",
+		})
+		return
+	}
+	c.JSON(http.StatusForbidden, gin.H{
+		"error": "you are not an admin of this event",
+	})
+}
+
 // GetEvents: query startDate & endDate (YYYY-MM-DD), or omit both for current UTC month; one alone is 400.
 func GetEvents(c *gin.Context) {
 	startQ := strings.TrimSpace(c.Query("startDate"))
@@ -121,7 +133,23 @@ func CreateEvent(c *gin.Context) {
 func DeleteEventByID(c *gin.Context) {
 	id := c.Param("id")
 
-	err := db.DeleteEventByID(id)
+	userID := c.GetString("userID")
+	userRole := c.GetString("userRole")
+
+	existingEvent, err := db.GetEventByID(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "event not found",
+		})
+		return
+	}
+
+	if !existingEvent.CanEdit(userID, userRole) {
+		writeEventEditForbidden(c, existingEvent)
+		return
+	}
+
+	err = db.DeleteEventByID(id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": "event not found",
@@ -138,18 +166,9 @@ func DeleteEventByID(c *gin.Context) {
 func UpdateEventByID(c *gin.Context) {
 	id := c.Param("id")
 
-	// Basic event-admin auth check:
-	// The caller must pass their user_id as a query parameter.
-	// We verify they are listed in the event's Admins before allowing the update.
-	userID := c.Query("user_id")
-	if userID == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "missing user_id query parameter",
-		})
-		return
-	}
+	userID := c.GetString("userID")
+	userRole := c.GetString("userRole")
 
-	// Fetch the existing event to verify admin access
 	existingEvent, err := db.GetEventByID(id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
@@ -158,11 +177,8 @@ func UpdateEventByID(c *gin.Context) {
 		return
 	}
 
-	// Check if user is an admin of this event
-	if !existingEvent.IsAdmin(userID) {
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": "you are not an admin of this event",
-		})
+	if !existingEvent.CanEdit(userID, userRole) {
+		writeEventEditForbidden(c, existingEvent)
 		return
 	}
 

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -192,6 +192,15 @@ func (e *Event) IsAdmin(userID string) bool {
 	return false
 }
 
+// CanEdit reports whether the caller may modify this event.
+// Admin-less events require callerSiteRole=admin; otherwise userID must be in Admins.
+func (e *Event) CanEdit(userID, callerSiteRole string) bool {
+	if len(e.Admins) == 0 {
+		return strings.EqualFold(strings.TrimSpace(callerSiteRole), RoleAdmin)
+	}
+	return e.IsAdmin(userID)
+}
+
 func (e *Event) ValidateRegistration(answers map[string]any) error {
 	for _, question := range e.RegistrationForm {
 		if !question.Required {


### PR DESCRIPTION
- Event.CanEdit: when Admins is empty, any site admin (user_role=admin) can edit; otherwise only listed admins.
- Event.IsListedAdmin: renamed from IsAdmin for clarity.
- PATCH/DELETE handlers: read user_id and user_role from query, return 401 when unauthenticated and 403 when unauthorized via CanEdit.
- Added doc comment on Admins field pointing at issue #65.
Admin Less tesing:
<img width="1726" height="293" alt="image" src="https://github.com/user-attachments/assets/9aae9554-27b6-4a85-bcfa-191d208e7869" />
No auth:
<img width="1658" height="165" alt="image" src="https://github.com/user-attachments/assets/67db1f27-46c9-4f07-898a-a23fa5dd6e9f" />
Token failed:
<img width="1749" height="162" alt="image" src="https://github.com/user-attachments/assets/b7696373-7c92-47b0-af97-81c1673fe643" />

Closes #65

