### PR TITLE
Add middleware to verify user auth via Clark

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SCE-Development/SCEvents/internal/config"
 	"github.com/SCE-Development/SCEvents/pkg/db"
 	"github.com/SCE-Development/SCEvents/pkg/handlers"
+	"github.com/SCE-Development/SCEvents/pkg/middleware"
 	"github.com/SCE-Development/SCEvents/pkg/registration"
 )
 
@@ -64,11 +65,16 @@ func main() {
 	{
 		events.GET("/", handlers.GetEvents)
 		events.GET("/:id", handlers.GetEventByID)
-		events.POST("/", handlers.CreateEvent)
-		events.POST("/:id/register", handlers.RegisterForEvent)
 		events.GET("/registrations/:request_id", handlers.GetRegistrationStatus)
-		events.DELETE("/:id", handlers.DeleteEventByID)
-		events.PATCH("/:id", handlers.UpdateEventByID)
+
+		protected := events.Group("/")
+		protected.Use(middleware.RequireAuth(middleware.MembershipStateNonMember, cfg.ClientAPIURL))
+		{
+			protected.POST("/", handlers.CreateEvent)
+			protected.POST("/:id/register", handlers.RegisterForEvent)
+			protected.DELETE("/:id", handlers.DeleteEventByID)
+			protected.PATCH("/:id", handlers.UpdateEventByID)
+		}
 	}
 
 	if err := r.Run(":" + cfg.ServerPort); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 5s 
+      start_period: 5s
 
   server:
     build:
@@ -37,6 +37,7 @@ services:
       - KAFKA_GROUP_ID=${KAFKA_GROUP_ID:-registration-consumers}
       - SERVER_PORT=${SERVER_PORT:-8002}
       - CLIENT_URL=${CLIENT_URL:-http://localhost:3000}
+      - CLIENT_API_URL=${CLIENT_API_URL:-http://host.docker.internal:8080}
 
   kafka:
     image: apache/kafka:3.8.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type AppConfig struct {
 	KafkaGroupID string
 	ServerPort   string
 	ClientURL    string
+	ClientAPIURL string
 }
 
 func Load() AppConfig {
@@ -21,6 +22,7 @@ func Load() AppConfig {
 		KafkaGroupID: getEnv("KAFKA_GROUP_ID", "registration-consumers"),
 		ServerPort:   getEnv("SERVER_PORT", "8002"),
 		ClientURL:    getEnv("CLIENT_URL", "http://localhost:3000"),
+		ClientAPIURL: getEnv("CLIENT_API_URL", "http://localhost:8080"),
 	}
 }
 

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// these should sync with Clark's membership states
+// https://github.com/SCE-Development/Clark/blob/a53f28bdb4e0b02e94d481102784922da4fc6e6d/src/Enums.js#L23-L30
+const (
+	MembershipStateBanned    = -2
+	MembershipStatePending   = -1
+	MembershipStateNonMember = 0
+	MembershipStateMember    = 1
+	MembershipStateOfficer   = 2
+	MembershipStateAdmin     = 3
+)
+
+func RequireAuth(minimumState int, clientAPIURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "No authorization header"})
+			return
+		}
+
+		req, _ := http.NewRequest("POST", clientAPIURL+"/api/Auth/verify", nil)
+		req.Header.Set("Authorization", authHeader)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			// if not success, the token was invalid or the API is down
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Token verification failed"})
+			return
+		}
+		defer resp.Body.Close()
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to read token verification response"})
+			return
+		}
+
+		log.Printf("API Response: %s\n", string(bodyBytes))
+
+		// parse Clark's response (decoded JWT payload)
+		var user map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &user); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse token verification response"})
+			return
+		}
+
+		// read accessLevel (float64 due to JSON unmarshaling)
+		accessLevel, ok := user["accessLevel"].(float64)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data from Clark API"})
+			return
+		}
+
+		if int(accessLevel) < minimumState {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Insufficient privileges"})
+			return
+		}
+
+		role := "User"
+		if int(accessLevel) >= MembershipStateOfficer {
+			role = "Admin"
+		}
+
+		userID, _ := user["_id"].(string)
+
+		c.Set("userID", userID)
+		c.Set("userRole", role)
+		c.Next()
+	}
+}


### PR DESCRIPTION
resolves #41

**CONTEXT**
- when a request from Clark is sent to SCEvents, we need a way to get the user's admin level
- it's weird b/c all the auth lives in Clark; however... there's an endpoint that we can access to auth in
- https://github.com/SCE-Development/Clark/issues/2085

**CHANGES**
- add middleware to intercept any requests made to SCEvents' authenticated routes
- this function will request auth information from Clark by using the request's JWT; response would look something like:

```json
{"firstName":"s","lastName":"s","email":"s@s.com","accessLevel":3,"pagesPrinted":0,"_id":"69e2fcf01b021f53d4560965","iat":1776483725,"exp":1776490925}
```
- from here we can store the user's information in context

**TESTING**
- tested in conjunction with another PR in Clark
- created event + got backend logs
```
[GIN-debug] Listening and serving HTTP on :8002
2026/04/18 03:50:59 API Response: {"firstName":"s","lastName":"s","email":"s@s.com","accessLevel":3,"pagesPrinted":0,"_id":"69e2fcf01b021f53d4560965","iat":1776483725,"exp":1776490925}
[GIN] 2026/04/18 - 03:50:59 | 201 |   29.4ms |      172.19.0.1 | POST     "/events/"
[GIN] 2026/04/18 - 03:50:59 | 200 |   6.08ms |      172.19.0.1 | GET      "/events/"
```


