### PR TITLE
Added Redis store unit tests with miniredis

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Build all packages
         run: go build ./...
+
+      - name: Run unit tests
+        run: go test ./...

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -46,6 +46,11 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	redisStore := db.NewRedisStore(db.RedisClient())
+	stores := &db.Stores{
+		Redis: redisStore,
+	}
+
 	producer := registration.NewProducer(
 		[]string{cfg.KafkaBroker},
 		cfg.KafkaTopic,
@@ -55,7 +60,10 @@ func main() {
 		[]string{cfg.KafkaBroker},
 		cfg.KafkaTopic,
 		cfg.KafkaGroupID,
+		stores,
 	)
+
+	eventHandler := handlers.NewEventHandler(stores)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -80,18 +88,18 @@ func main() {
 
 	events := r.Group("/events")
 	{
-		events.GET("/", handlers.GetEvents)
-		events.GET("/:id", handlers.GetEventByID)
-		events.GET("/registrations/:request_id", handlers.GetRegistrationStatus)
+		events.GET("/", eventHandler.GetEvents)
+		events.GET("/:id", eventHandler.GetEventByID)
+		events.GET("/registrations/:request_id", eventHandler.GetRegistrationStatus)
 
 		protected := events.Group("/")
 		protected.Use(middleware.RequireAuth(middleware.MembershipStateNonMember, cfg.ClientAPIURL))
 		{
-			protected.POST("/", handlers.CreateEvent)
-			protected.POST("/:id/register", handlers.RegisterForEvent(producer))
-			protected.POST("/:id/waitlist", handlers.JoinEventWaitlist)
-			protected.DELETE("/:id", handlers.DeleteEventByID)
-			protected.PATCH("/:id", handlers.UpdateEventByID)
+			protected.POST("/", eventHandler.CreateEvent)
+			protected.POST("/:id/register", eventHandler.RegisterForEvent(producer))
+			protected.POST("/:id/waitlist", eventHandler.JoinEventWaitlist)
+			protected.DELETE("/:id", eventHandler.DeleteEventByID)
+			protected.PATCH("/:id", eventHandler.UpdateEventByID)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/SCE-Development/SCEvents
 go 1.25.5
 
 require (
+	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/redis/go-redis/v9 v9.7.0
@@ -43,6 +44,7 @@ require (
 	github.com/xdg-go/scram v1.2.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	golang.org/x/arch v0.25.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -123,6 +125,8 @@ github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gi
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
 go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=

--- a/pkg/db/redis.go
+++ b/pkg/db/redis.go
@@ -12,16 +12,14 @@ var (
 	redisClient *redis.Client
 )
 
-
-// Connect initializes the global Redis client using the provided address.
-
+// ConnectRedis initializes the global Redis client using the provided address.
 func ConnectRedis(addr string) error {
 	redisClient = redis.NewClient(&redis.Options{
-		Addr: addr,
-		Password: "", 
-		DB: 0, 
+		Addr:     addr,
+		Password: "",
+		DB:       0,
 	})
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	// Test the connection with a ping
@@ -33,7 +31,7 @@ func ConnectRedis(addr string) error {
 	return nil
 }
 
-// Disconnect closes the global Redis client if it has been initialized.
+// DisconnectRedis closes the global Redis client if it has been initialized.
 func DisconnectRedis() error {
 	if redisClient == nil {
 		return nil
@@ -50,8 +48,15 @@ func RedisClient() *redis.Client {
 	return redisClient
 }
 
+type redisStore struct {
+	client *redis.Client
+}
+
+func NewRedisStore(client *redis.Client) RedisStore {
+	return &redisStore{client: client}
+}
+
 // EventHeadcountKey returns the Redis key for an event's headcount (capacity).
-// Pattern: event:{event_id}:headcount -> value: capacity (integer).
 func EventHeadcountKey(eventID string) string {
 	return fmt.Sprintf("event:%s:headcount", eventID)
 }
@@ -60,27 +65,20 @@ func EventRegistrantsKey(eventID string) string {
 	return fmt.Sprintf("event:%s:registrants", eventID)
 }
 
-func SetEventHeadcount(eventID string, capacity int) error {
-	if redisClient == nil {
+func (s *redisStore) SetEventHeadcount(ctx context.Context, eventID string, capacity int) error {
+	if s.client == nil {
 		return fmt.Errorf("redis not connected")
 	}
-	ctx := context.Background()
 	key := EventHeadcountKey(eventID)
-	return redisClient.Set(ctx, key, capacity, 0).Err()
+	return s.client.Set(ctx, key, capacity, 0).Err()
 }
 
-// GetEventHeadcount returns the current remaining headcount for an event from Redis.
-func GetEventHeadcount(eventID string) (int, error) {
-	if redisClient == nil {
+func (s *redisStore) GetEventHeadcount(ctx context.Context, eventID string) (int, error) {
+	if s.client == nil {
 		return 0, fmt.Errorf("redis not connected")
 	}
-	ctx := context.Background()
 	key := EventHeadcountKey(eventID)
-	val, err := redisClient.Get(ctx, key).Int()
-	if err != nil {
-		return 0, err
-	}
-	return val, nil
+	return s.client.Get(ctx, key).Int()
 }
 
 var takeSeatScript = redis.NewScript(`
@@ -98,21 +96,15 @@ redis.call("DECR", KEYS[1])
 return 1
 `)
 
-// TryTakeEventSeat atomically checks whether the event has remaining capacity
-// and decrements it by 1 only if capacity is available.
-func TryTakeEventSeat(eventID string) (bool, error) {
-	if redisClient == nil {
+func (s *redisStore) TryTakeEventSeat(ctx context.Context, eventID string) (bool, error) {
+	if s.client == nil {
 		return false, fmt.Errorf("redis not connected")
 	}
-
-	ctx := context.Background()
 	key := EventHeadcountKey(eventID)
-
-	result, err := takeSeatScript.Run(ctx, redisClient, []string{key}).Int()
+	result, err := takeSeatScript.Run(ctx, s.client, []string{key}).Int()
 	if err != nil {
 		return false, err
 	}
-
 	switch result {
 	case 1:
 		return true, nil
@@ -125,27 +117,25 @@ func TryTakeEventSeat(eventID string) (bool, error) {
 	}
 }
 
-// ReleaseEventSeat adds 1 back to the remaining capacity.
-func ReleaseEventSeat(eventID string) error {
-	if redisClient == nil {
+func (s *redisStore) ReleaseEventSeat(ctx context.Context, eventID string) error {
+	if s.client == nil {
 		return fmt.Errorf("redis not connected")
 	}
-
-	ctx := context.Background()
 	key := EventHeadcountKey(eventID)
-
-	return redisClient.Incr(ctx, key).Err()
+	return s.client.Incr(ctx, key).Err()
 }
 
-func IsUserRegisteredForEvent(eventID string, userID string) (bool, error) {
-	if redisClient == nil {
+func (s *redisStore) IsUserRegisteredForEvent(ctx context.Context, eventID string, userID string) (bool, error) {
+	if s.client == nil {
 		return false, fmt.Errorf("redis not connected")
 	}
-	ctx := context.Background()
 	key := EventRegistrantsKey(eventID)
-	isMember, err := redisClient.SIsMember(ctx, key, userID).Result()
-	if err != nil {
-		return false, err
+	return s.client.SIsMember(ctx, key, userID).Result()
+}
+
+func (s *redisStore) Close() error {
+	if s.client == nil {
+		return nil
 	}
-	return isMember, nil
+	return s.client.Close()
 }

--- a/pkg/db/redis_keys_test.go
+++ b/pkg/db/redis_keys_test.go
@@ -1,0 +1,19 @@
+package db
+
+import "testing"
+
+func TestEventHeadcountKey(t *testing.T) {
+	got := EventHeadcountKey("event-123")
+	want := "event:event-123:headcount"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestEventRegistrantsKey(t *testing.T) {
+	got := EventRegistrantsKey("event-123")
+	want := "event:event-123:registrants"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/pkg/db/redis_test.go
+++ b/pkg/db/redis_test.go
@@ -1,0 +1,174 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestRedisStore(t *testing.T) RedisStore {
+	t.Helper()
+
+	srv, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+
+	client := redis.NewClient(&redis.Options{
+		Addr: srv.Addr(),
+	})
+
+	store := NewRedisStore(client)
+
+	t.Cleanup(func() {
+		_ = store.Close()
+		srv.Close()
+	})
+
+	return store
+}
+
+func TestSetAndGetEventHeadcount(t *testing.T) {
+	store := newTestRedisStore(t)
+
+	if err := store.SetEventHeadcount(context.Background(), "event-1", 10); err != nil {
+		t.Fatalf("SetEventHeadcount failed: %v", err)
+	}
+
+	got, err := store.GetEventHeadcount(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("GetEventHeadcount failed: %v", err)
+	}
+	if got != 10 {
+		t.Fatalf("expected 10, got %d", got)
+	}
+}
+
+func TestTryTakeEventSeatSuccessAndDecrement(t *testing.T) {
+	store := newTestRedisStore(t)
+
+	if err := store.SetEventHeadcount(context.Background(), "event-1", 2); err != nil {
+		t.Fatalf("SetEventHeadcount failed: %v", err)
+	}
+
+	ok, err := store.TryTakeEventSeat(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("TryTakeEventSeat failed: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected seat acquisition to succeed")
+	}
+
+	remaining, err := store.GetEventHeadcount(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("GetEventHeadcount failed: %v", err)
+	}
+	if remaining != 1 {
+		t.Fatalf("expected remaining 1, got %d", remaining)
+	}
+}
+
+func TestTryTakeEventSeatFullEvent(t *testing.T) {
+	store := newTestRedisStore(t)
+
+	if err := store.SetEventHeadcount(context.Background(), "event-1", 0); err != nil {
+		t.Fatalf("SetEventHeadcount failed: %v", err)
+	}
+
+	ok, err := store.TryTakeEventSeat(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("TryTakeEventSeat failed: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected seat acquisition to fail when full")
+	}
+
+	remaining, err := store.GetEventHeadcount(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("GetEventHeadcount failed: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("expected remaining 0, got %d", remaining)
+	}
+}
+
+func TestTryTakeEventSeatMissingHeadcount(t *testing.T) {
+	store := newTestRedisStore(t)
+
+	ok, err := store.TryTakeEventSeat(context.Background(), "missing-event")
+	if err == nil {
+		t.Fatalf("expected error for missing event headcount")
+	}
+	if ok {
+		t.Fatalf("expected ok=false for missing event headcount")
+	}
+	if !strings.Contains(err.Error(), "missing Redis headcount") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReleaseEventSeat(t *testing.T) {
+	store := newTestRedisStore(t)
+
+	if err := store.SetEventHeadcount(context.Background(), "event-1", 1); err != nil {
+		t.Fatalf("SetEventHeadcount failed: %v", err)
+	}
+	if err := store.ReleaseEventSeat(context.Background(), "event-1"); err != nil {
+		t.Fatalf("ReleaseEventSeat failed: %v", err)
+	}
+
+	remaining, err := store.GetEventHeadcount(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("GetEventHeadcount failed: %v", err)
+	}
+	if remaining != 2 {
+		t.Fatalf("expected remaining 2, got %d", remaining)
+	}
+}
+
+func TestTryTakeEventSeatConcurrentNoOversell(t *testing.T) {
+	store := newTestRedisStore(t)
+
+	const capacity = 25
+	const attempts = 100
+
+	if err := store.SetEventHeadcount(context.Background(), "event-1", capacity); err != nil {
+		t.Fatalf("SetEventHeadcount failed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	var successCount atomic.Int64
+
+	wg.Add(attempts)
+	for range attempts {
+		go func() {
+			defer wg.Done()
+			ok, err := store.TryTakeEventSeat(context.Background(), "event-1")
+			if err != nil {
+				t.Errorf("TryTakeEventSeat failed: %v", err)
+				return
+			}
+			if ok {
+				successCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := int(successCount.Load()); got != capacity {
+		t.Fatalf("expected %d successes, got %d", capacity, got)
+	}
+
+	remaining, err := store.GetEventHeadcount(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("GetEventHeadcount failed: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("expected remaining 0, got %d", remaining)
+	}
+}

--- a/pkg/db/stores.go
+++ b/pkg/db/stores.go
@@ -1,0 +1,20 @@
+package db
+
+import (
+	"context"
+)
+
+type RedisStore interface {
+	SetEventHeadcount(ctx context.Context, eventID string, capacity int) error
+	GetEventHeadcount(ctx context.Context, eventID string) (int, error)
+	TryTakeEventSeat(ctx context.Context, eventID string) (bool, error)
+	ReleaseEventSeat(ctx context.Context, eventID string) error
+	IsUserRegisteredForEvent(ctx context.Context, eventID string, userID string) (bool, error)
+	Close() error
+}
+
+type Stores struct {
+	Redis RedisStore
+	// Mongo MongoStore 
+	// Kafka KafkaClient
+}

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -16,6 +16,14 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+type EventHandler struct {
+	stores *db.Stores
+}
+
+func NewEventHandler(stores *db.Stores) *EventHandler {
+	return &EventHandler{stores: stores}
+}
+
 const dateLayout = "2006-01-02"
 
 func writeEventEditForbidden(c *gin.Context, ev *models.Event) {
@@ -31,7 +39,7 @@ func writeEventEditForbidden(c *gin.Context, ev *models.Event) {
 }
 
 // GetEvents: query startDate & endDate (YYYY-MM-DD), or omit both for current UTC month; one alone is 400.
-func GetEvents(c *gin.Context) {
+func (h *EventHandler) GetEvents(c *gin.Context) {
 	startQ := strings.TrimSpace(c.Query("startDate"))
 	endQ := strings.TrimSpace(c.Query("endDate"))
 
@@ -75,7 +83,7 @@ func GetEvents(c *gin.Context) {
 }
 
 // returns a single event by ID
-func GetEventByID(c *gin.Context) {
+func (h *EventHandler) GetEventByID(c *gin.Context) {
 	id := c.Param("id")
 
 	event, err := db.GetEventByID(id)
@@ -90,7 +98,7 @@ func GetEventByID(c *gin.Context) {
 }
 
 // creates a new event
-func CreateEvent(c *gin.Context) {
+func (h *EventHandler) CreateEvent(c *gin.Context) {
 	var event models.Event
 
 	// parse JSON request body into struct
@@ -119,7 +127,7 @@ func CreateEvent(c *gin.Context) {
 		return
 	}
 
-	if err := db.SetEventHeadcount(createdEvent.ID, createdEvent.MaxAttendees); err != nil {
+	if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), createdEvent.ID, createdEvent.MaxAttendees); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "failed to store event headcount",
 		})
@@ -130,7 +138,7 @@ func CreateEvent(c *gin.Context) {
 }
 
 // deletes an event by ID
-func DeleteEventByID(c *gin.Context) {
+func (h *EventHandler) DeleteEventByID(c *gin.Context) {
 	id := c.Param("id")
 
 	userID := c.GetString("userID")
@@ -163,7 +171,7 @@ func DeleteEventByID(c *gin.Context) {
 }
 
 // updates an event by ID (partial update)
-func UpdateEventByID(c *gin.Context) {
+func (h *EventHandler) UpdateEventByID(c *gin.Context) {
 	id := c.Param("id")
 
 	userID := c.GetString("userID")
@@ -245,7 +253,7 @@ func UpdateEventByID(c *gin.Context) {
 	if maxAttendees, ok := fields["max_attendees"]; ok {
 		if newMax, ok := maxAttendees.(float64); ok {
 			// Get current remaining seats from Redis
-			currentRemaining, err := db.GetEventHeadcount(id)
+			currentRemaining, err := h.stores.Redis.GetEventHeadcount(c.Request.Context(), id)
 			if err != nil {
 				// If Redis key doesn't exist yet, no seats have been taken
 				currentRemaining = existingEvent.MaxAttendees
@@ -260,7 +268,7 @@ func UpdateEventByID(c *gin.Context) {
 				newRemaining = 0
 			}
 
-			if err := db.SetEventHeadcount(id, newRemaining); err != nil {
+			if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), id, newRemaining); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{
 					"error": "event updated but failed to sync headcount in Redis",
 				})
@@ -275,7 +283,7 @@ func UpdateEventByID(c *gin.Context) {
 }
 
 // RegisterForEvent writes a pending registration to MongoDB, publishes a reference message to Kafka, and returns 202 Accepted.
-func RegisterForEvent(producer *registration.Producer) gin.HandlerFunc {
+func (h *EventHandler) RegisterForEvent(producer *registration.Producer) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		eventID := c.Param("id")
 		if eventID == "" {
@@ -375,7 +383,7 @@ func RegisterForEvent(producer *registration.Producer) gin.HandlerFunc {
 	}
 }
 
-func JoinEventWaitlist(c *gin.Context) {
+func (h *EventHandler) JoinEventWaitlist(c *gin.Context) {
 	eventID := c.Param("id")
 	if strings.TrimSpace(eventID) == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -469,7 +477,7 @@ func JoinEventWaitlist(c *gin.Context) {
 			})
 			return
 		}
-		
+
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "failed to join waitlist",
 		})
@@ -482,7 +490,7 @@ func JoinEventWaitlist(c *gin.Context) {
 	})
 }
 
-func GetRegistrationStatus(c *gin.Context) {
+func (h *EventHandler) GetRegistrationStatus(c *gin.Context) {
 	requestID := c.Param("request_id")
 	if strings.TrimSpace(requestID) == "" {
 		c.JSON(http.StatusBadRequest, gin.H{

--- a/pkg/registration/consumer.go
+++ b/pkg/registration/consumer.go
@@ -14,9 +14,10 @@ import (
 
 type Consumer struct {
 	reader *kafka.Reader
+	stores *db.Stores
 }
 
-func NewConsumer(brokers []string, topic string, groupID string) *Consumer {
+func NewConsumer(brokers []string, topic string, groupID string, stores *db.Stores) *Consumer {
 	r := kafka.NewReader(kafka.ReaderConfig{
 		Brokers:        brokers,
 		Topic:          topic,
@@ -24,7 +25,10 @@ func NewConsumer(brokers []string, topic string, groupID string) *Consumer {
 		CommitInterval: 0,
 	})
 
-	return &Consumer{reader: r}
+	return &Consumer{
+		reader: r,
+		stores: stores,
+	}
 }
 
 func (c *Consumer) Run(ctx context.Context) {
@@ -38,7 +42,7 @@ func (c *Consumer) Run(ctx context.Context) {
 			continue
 		}
 
-		if err := ProcessKafkaMessage(msg.Value); err != nil {
+		if err := c.processKafkaMessage(ctx, msg.Value); err != nil {
 			log.Printf("consumer process error: %v", err)
 			continue
 		}
@@ -57,7 +61,7 @@ func (c *Consumer) Close() error {
 	return c.reader.Close()
 }
 
-func ProcessKafkaMessage(raw []byte) error {
+func (c *Consumer) processKafkaMessage(ctx context.Context, raw []byte) error {
 	var msg models.KafkaRegistrationMessage
 	if err := json.Unmarshal(raw, &msg); err != nil {
 		return err
@@ -92,7 +96,7 @@ func ProcessKafkaMessage(raw []byte) error {
 		return db.MarkRegistrationRejected(msg.RequestID, models.ReasonDuplicateUser)
 	}
 
-	ok, err := db.TryTakeEventSeat(msg.EventID)
+	ok, err := c.stores.Redis.TryTakeEventSeat(ctx, msg.EventID)
 	if err != nil {
 		return err
 	}
@@ -101,7 +105,7 @@ func ProcessKafkaMessage(raw []byte) error {
 	}
 
 	if err := db.MarkRegistrationAccepted(msg.RequestID); err != nil {
-		_ = db.ReleaseEventSeat(msg.EventID)
+		_ = c.stores.Redis.ReleaseEventSeat(ctx, msg.EventID)
 		return err
 	}
 


### PR DESCRIPTION
For issue #54 and subissue #75

## Problem
Redis seat/headcount logic is critical to registration correctness, but Redis behavior coverage was minimal.
Without tests around seat decrementing and full-capacity behavior, regressions could slip through.

## Solution
Added Redis-focused tests in pkg/db using miniredis to validate store behavior without relying on an external Redis service.

## Covered scenarios include:
- set/get event headcount
- successful seat take with decrement
- full event seat rejection
- missing headcount key error path
- seat release increment
- concurrent seat-take no-oversell behavior
- key format helper validation

## Files changed
- pkg/db/redis_test.go
- go.mod + go.sum
- pkg/db/redis_keys_test.go
- cmd/server/main.go
- pkg/handlers/event.go
- pkg/registration/consumer.go

## How to run tests
From project root (SCEvents):

`go test ./...`

Optional package-only run:

`go test -v ./pkg/db`