### PR TITLE
Added MongoStore interface and mtest unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect

--- a/pkg/db/event.go
+++ b/pkg/db/event.go
@@ -128,3 +128,81 @@ func UpdateEventByID(id string, fields map[string]interface{}) error {
 
 	return nil
 }
+
+func (s *mongoStore) GetEvents(ctx context.Context, startDate, endDate string) ([]models.Event, error) {
+	filter := bson.M{
+		"$and": bson.A{
+			bson.M{"date": bson.M{"$lte": endDate}},
+			bson.M{
+				"$or": bson.A{
+					bson.M{
+						"$and": bson.A{
+							bson.M{"$or": bson.A{
+								bson.M{"end_date": bson.M{"$exists": false}},
+								bson.M{"end_date": nil},
+								bson.M{"end_date": ""},
+							}},
+							bson.M{"date": bson.M{"$gte": startDate}},
+						},
+					},
+					bson.M{"end_date": bson.M{"$gte": startDate}},
+				},
+			},
+		},
+	}
+	cursor, err := s.events.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	events := make([]models.Event, 0)
+	if err := cursor.All(ctx, &events); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func (s *mongoStore) GetEventByID(ctx context.Context, id string) (*models.Event, error) {
+	var e models.Event
+	err := s.events.FindOne(ctx, bson.M{"_id": id}).Decode(&e)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (s *mongoStore) CreateEvent(ctx context.Context, e models.Event) (*models.Event, error) {
+	if e.ID == "" {
+		e.ID = primitive.NewObjectID().Hex()
+	}
+	_, err := s.events.InsertOne(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (s *mongoStore) DeleteEventByID(ctx context.Context, id string) error {
+	result, err := s.events.DeleteOne(ctx, bson.M{"_id": id})
+	if err != nil {
+		return err
+	}
+	if result.DeletedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+func (s *mongoStore) UpdateEventByID(ctx context.Context, id string, fields map[string]interface{}) error {
+	update := bson.M{
+		"$set": fields,
+	}
+	result, err := s.events.UpdateOne(ctx, bson.M{"_id": id}, update)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}

--- a/pkg/db/event_test.go
+++ b/pkg/db/event_test.go
@@ -1,0 +1,212 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SCE-Development/SCEvents/pkg/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestCreateEvent(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("success", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		mt.AddMockResponses(mtest.CreateSuccessResponse())
+		event := models.Event{
+			ID:           "event-1",
+			Name:         "Test Event",
+			Date:         "2026-05-01",
+			Time:         "10:00",
+			Location:     "Room 101",
+			MaxAttendees: 50,
+		}
+		result, err := store.CreateEvent(context.Background(), event)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result.ID != "event-1" {
+			t.Fatalf("expected ID event-1, got %s", result.ID)
+		}
+	})
+
+	mt.Run("generates ID when empty", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		mt.AddMockResponses(mtest.CreateSuccessResponse())
+		event := models.Event{
+			Name:     "Test Event",
+			Date:     "2026-05-01",
+			Time:     "10:00",
+			Location: "Room 101",
+		}
+		result, err := store.CreateEvent(context.Background(), event)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result.ID == "" {
+			t.Fatal("expected generated ID, got empty")
+		}
+	})
+
+	mt.Run("duplicate key error", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		mt.AddMockResponses(mtest.CreateWriteErrorsResponse(mtest.WriteError{
+			Index:   0,
+			Code:    11000,
+			Message: "duplicate key error",
+		}))
+		event := models.Event{
+			ID:   "event-1",
+			Name: "Test Event",
+			Date: "2026-05-01",
+			Time: "10:00",
+		}
+		_, err := store.CreateEvent(context.Background(), event)
+		if err == nil {
+			t.Fatal("expected error for duplicate key")
+		}
+	})
+}
+
+func TestGetEventByID(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("found", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
+			{"_id", "event-1"},
+			{"name", "Test Event"},
+			{"date", "2026-05-01"},
+			{"time", "10:00"},
+			{"location", "Room 101"},
+			{"max_attendees", int32(50)},
+		}))
+		result, err := store.GetEventByID(context.Background(), "event-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result.ID != "event-1" {
+			t.Fatalf("expected ID event-1, got %s", result.ID)
+		}
+		if result.Name != "Test Event" {
+			t.Fatalf("expected name 'Test Event', got %s", result.Name)
+		}
+	})
+
+	mt.Run("not found", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
+		_, err := store.GetEventByID(context.Background(), "nonexistent")
+		if err != mongo.ErrNoDocuments {
+			t.Fatalf("expected ErrNoDocuments, got %v", err)
+		}
+	})
+}
+
+func TestDeleteEventByID(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("success", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		mt.AddMockResponses(bson.D{{"ok", 1}, {"n", int32(1)}})
+		if err := store.DeleteEventByID(context.Background(), "event-1"); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	mt.Run("not found", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		mt.AddMockResponses(bson.D{{"ok", 1}, {"n", int32(0)}})
+		err := store.DeleteEventByID(context.Background(), "nonexistent")
+		if err != mongo.ErrNoDocuments {
+			t.Fatalf("expected ErrNoDocuments, got %v", err)
+		}
+	})
+}
+
+func TestUpdateEventByID(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("success", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		mt.AddMockResponses(bson.D{
+			{"ok", 1},
+			{"n", int32(1)},
+			{"nModified", int32(1)},
+		})
+		err := store.UpdateEventByID(context.Background(), "event-1", map[string]interface{}{
+			"name": "Updated Name",
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	mt.Run("not found", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		mt.AddMockResponses(bson.D{
+			{"ok", 1},
+			{"n", int32(0)},
+			{"nModified", int32(0)},
+		})
+		err := store.UpdateEventByID(context.Background(), "nonexistent", map[string]interface{}{
+			"name": "Updated Name",
+		})
+		if err != mongo.ErrNoDocuments {
+			t.Fatalf("expected ErrNoDocuments, got %v", err)
+		}
+	})
+}
+
+func TestGetEvents(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("returns matching events", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch,
+			bson.D{
+				{"_id", "event-1"},
+				{"name", "Event One"},
+				{"date", "2026-05-01"},
+				{"time", "10:00"},
+				{"location", "Room 101"},
+			},
+			bson.D{
+				{"_id", "event-2"},
+				{"name", "Event Two"},
+				{"date", "2026-05-15"},
+				{"time", "14:00"},
+				{"location", "Room 202"},
+			},
+		))
+		events, err := store.GetEvents(context.Background(), "2026-05-01", "2026-05-31")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(events) != 2 {
+			t.Fatalf("expected 2 events, got %d", len(events))
+		}
+		if events[0].ID != "event-1" {
+			t.Fatalf("expected first event ID event-1, got %s", events[0].ID)
+		}
+	})
+
+	mt.Run("empty result", func(mt *mtest.T) {
+		store := NewMongoStore(mt.Coll, nil)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
+		events, err := store.GetEvents(context.Background(), "2026-05-01", "2026-05-31")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("expected 0 events, got %d", len(events))
+		}
+	})
+}

--- a/pkg/db/registration.go
+++ b/pkg/db/registration.go
@@ -173,3 +173,114 @@ func MarkRegistrationRejected(requestID string, reason models.DecisionReason) er
 
 	return nil
 }
+
+func (s *mongoStore) CreatePendingRegistration(ctx context.Context, r models.RegistrationRequest) (*models.RegistrationRequest, error) {
+	now := time.Now().UTC()
+	r.Status = models.StatusPending
+	r.DecisionReason = models.ReasonNone
+	r.CreatedAt = now
+	r.UpdatedAt = now
+	r.ProcessedAt = nil
+	_, err := s.registrations.InsertOne(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func (s *mongoStore) GetRegistrationByID(ctx context.Context, requestID string) (*models.RegistrationRequest, error) {
+	var r models.RegistrationRequest
+	err := s.registrations.FindOne(ctx, bson.M{"_id": requestID}).Decode(&r)
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func (s *mongoStore) HasAcceptedRegistration(ctx context.Context, eventID, userID string) (bool, error) {
+	filter := bson.M{
+		"event_id":           eventID,
+		"registrant.user_id": userID,
+		"status":             models.StatusAccepted,
+	}
+	err := s.registrations.FindOne(ctx, filter).Err()
+	if err == mongo.ErrNoDocuments {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *mongoStore) HasPendingOrAcceptedRegistration(ctx context.Context, eventID, userID string) (bool, error) {
+	filter := bson.M{
+		"event_id":           eventID,
+		"registrant.user_id": userID,
+		"status": bson.M{
+			"$in": []models.Status{models.StatusPending, models.StatusAccepted},
+		},
+	}
+	err := s.registrations.FindOne(ctx, filter).Err()
+	if err == mongo.ErrNoDocuments {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *mongoStore) MarkRegistrationAccepted(ctx context.Context, requestID string) error {
+	now := time.Now().UTC()
+	update := bson.M{
+		"$set": bson.M{
+			"status":          models.StatusAccepted,
+			"decision_reason": models.ReasonNone,
+			"updated_at":      now,
+			"processed_at":    now,
+		},
+	}
+	result, err := s.registrations.UpdateOne(
+		ctx,
+		bson.M{
+			"_id":    requestID,
+			"status": models.StatusPending,
+		},
+		update,
+	)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+func (s *mongoStore) MarkRegistrationRejected(ctx context.Context, requestID string, reason models.DecisionReason) error {
+	now := time.Now().UTC()
+	update := bson.M{
+		"$set": bson.M{
+			"status":          models.StatusRejected,
+			"decision_reason": reason,
+			"updated_at":      now,
+			"processed_at":    now,
+		},
+	}
+	result, err := s.registrations.UpdateOne(
+		ctx,
+		bson.M{
+			"_id":    requestID,
+			"status": models.StatusPending,
+		},
+		update,
+	)
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}

--- a/pkg/db/registration_test.go
+++ b/pkg/db/registration_test.go
@@ -1,0 +1,207 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SCE-Development/SCEvents/pkg/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+func TestCreatePendingRegistration(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("success", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		mt.AddMockResponses(mtest.CreateSuccessResponse())
+		req := models.RegistrationRequest{
+			RequestID: "req-1",
+			EventID:   "event-1",
+			Registrant: models.Registrant{
+				Name:   "John Doe",
+				Email:  "john@example.com",
+				UserID: "user-1",
+			},
+		}
+		result, err := store.CreatePendingRegistration(context.Background(), req)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result.RequestID != "req-1" {
+			t.Fatalf("expected request ID req-1, got %s", result.RequestID)
+		}
+		if result.Status != models.StatusPending {
+			t.Fatalf("expected status pending, got %s", result.Status)
+		}
+		if result.ProcessedAt != nil {
+			t.Fatal("expected ProcessedAt to be nil")
+		}
+	})
+}
+
+func TestGetRegistrationByID(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("found", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
+			{"_id", "req-1"},
+			{"event_id", "event-1"},
+			{"status", "pending"},
+			{"registrant", bson.D{
+				{"name", "John Doe"},
+				{"email", "john@example.com"},
+				{"user_id", "user-1"},
+			}},
+		}))
+		result, err := store.GetRegistrationByID(context.Background(), "req-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result.RequestID != "req-1" {
+			t.Fatalf("expected request ID req-1, got %s", result.RequestID)
+		}
+		if result.Registrant.UserID != "user-1" {
+			t.Fatalf("expected user ID user-1, got %s", result.Registrant.UserID)
+		}
+	})
+
+	mt.Run("not found", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
+		_, err := store.GetRegistrationByID(context.Background(), "nonexistent")
+		if err != mongo.ErrNoDocuments {
+			t.Fatalf("expected ErrNoDocuments, got %v", err)
+		}
+	})
+}
+
+func TestHasAcceptedRegistration(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("exists", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
+			{"_id", "req-1"},
+			{"event_id", "event-1"},
+			{"status", "accepted"},
+		}))
+		exists, err := store.HasAcceptedRegistration(context.Background(), "event-1", "user-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !exists {
+			t.Fatal("expected true, got false")
+		}
+	})
+
+	mt.Run("does not exist", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
+		exists, err := store.HasAcceptedRegistration(context.Background(), "event-1", "user-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if exists {
+			t.Fatal("expected false, got true")
+		}
+	})
+}
+
+func TestHasPendingOrAcceptedRegistration(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("exists", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
+			{"_id", "req-1"},
+			{"event_id", "event-1"},
+			{"status", "pending"},
+		}))
+		exists, err := store.HasPendingOrAcceptedRegistration(context.Background(), "event-1", "user-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !exists {
+			t.Fatal("expected true, got false")
+		}
+	})
+
+	mt.Run("does not exist", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
+		exists, err := store.HasPendingOrAcceptedRegistration(context.Background(), "event-1", "user-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if exists {
+			t.Fatal("expected false, got true")
+		}
+	})
+}
+
+func TestMarkRegistrationAccepted(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("success", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		mt.AddMockResponses(bson.D{
+			{"ok", 1},
+			{"n", int32(1)},
+			{"nModified", int32(1)},
+		})
+		if err := store.MarkRegistrationAccepted(context.Background(), "req-1"); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	mt.Run("not found", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		mt.AddMockResponses(bson.D{
+			{"ok", 1},
+			{"n", int32(0)},
+			{"nModified", int32(0)},
+		})
+		err := store.MarkRegistrationAccepted(context.Background(), "nonexistent")
+		if err != mongo.ErrNoDocuments {
+			t.Fatalf("expected ErrNoDocuments, got %v", err)
+		}
+	})
+}
+
+func TestMarkRegistrationRejected(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("success", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		mt.AddMockResponses(bson.D{
+			{"ok", 1},
+			{"n", int32(1)},
+			{"nModified", int32(1)},
+		})
+		if err := store.MarkRegistrationRejected(context.Background(), "req-1", models.ReasonCapacityFull); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	mt.Run("not found", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		mt.AddMockResponses(bson.D{
+			{"ok", 1},
+			{"n", int32(0)},
+			{"nModified", int32(0)},
+		})
+		err := store.MarkRegistrationRejected(context.Background(), "nonexistent", models.ReasonCapacityFull)
+		if err != mongo.ErrNoDocuments {
+			t.Fatalf("expected ErrNoDocuments, got %v", err)
+		}
+	})
+}

--- a/pkg/db/stores.go
+++ b/pkg/db/stores.go
@@ -2,6 +2,9 @@ package db
 
 import (
 	"context"
+
+	"github.com/SCE-Development/SCEvents/pkg/models"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type RedisStore interface {
@@ -13,8 +16,30 @@ type RedisStore interface {
 	Close() error
 }
 
+type MongoStore interface {
+	GetEvents(ctx context.Context, startDate, endDate string) ([]models.Event, error)
+	GetEventByID(ctx context.Context, id string) (*models.Event, error)
+	CreateEvent(ctx context.Context, e models.Event) (*models.Event, error)
+	DeleteEventByID(ctx context.Context, id string) error
+	UpdateEventByID(ctx context.Context, id string, fields map[string]interface{}) error
+	CreatePendingRegistration(ctx context.Context, r models.RegistrationRequest) (*models.RegistrationRequest, error)
+	GetRegistrationByID(ctx context.Context, requestID string) (*models.RegistrationRequest, error)
+	HasAcceptedRegistration(ctx context.Context, eventID, userID string) (bool, error)
+	HasPendingOrAcceptedRegistration(ctx context.Context, eventID, userID string) (bool, error)
+	MarkRegistrationAccepted(ctx context.Context, requestID string) error
+	MarkRegistrationRejected(ctx context.Context, requestID string, reason models.DecisionReason) error
+}
+
 type Stores struct {
 	Redis RedisStore
-	// Mongo MongoStore 
-	// Kafka KafkaClient
+	Mongo MongoStore
+}
+
+type mongoStore struct {
+	events        *mongo.Collection
+	registrations *mongo.Collection
+}
+
+func NewMongoStore(events, registrations *mongo.Collection) MongoStore {
+	return &mongoStore{events: events, registrations: registrations}
 }


### PR DESCRIPTION
## PR for issue #51 and sub-issue #76

### Problem
MongoDB operations are called as package-level functions (e.g. `db.GetEventByID(id)`), making them impossible to unit test without a running MongoDB instance. We need an interface-based abstraction to enable dependency injection and mock-based testing, following the same pattern established for Redis.

### Solution
Add a 'MongoStore` interface for all 11 event and registration MongoDB operations with a real `mongoStore` implementation using receiver methods. Unit tests use MongoDB's official `mtest` package to mock wire-protocol responses, requiring no external services.

### Files Changed

| File | Status | Description |
|---|---|---|
| `pkg/db/stores.go` | **Added** | `MongoStore` interface, `mongoStore` struct, `NewMongoStore` constructor |
| `pkg/db/event.go` | **Modified** | Added 5 receiver methods on `mongoStore` for event operations |
| `pkg/db/registration.go` | **Modified** | Added 6 receiver methods on `mongoStore` for registration operations |
| `pkg/db/event_test.go` | **Added** | 10 test cases across 5 test functions for event operations |
| `pkg/db/registration_test.go` | **Added** | 12 test cases across 6 test functions for registration operations |

### How to Run Tests
```bash
go test ./pkg/db/... -v -count=1
```