### PR TITLE
Fix unlimited attendees logic

### DIFF
--- a/pkg/db/redis.go
+++ b/pkg/db/redis.go
@@ -81,6 +81,14 @@ func (s *redisStore) GetEventHeadcount(ctx context.Context, eventID string) (int
 	return s.client.Get(ctx, key).Int()
 }
 
+func (s *redisStore) DeleteEventHeadcount(ctx context.Context, eventID string) error {
+	if s.client == nil {
+		return fmt.Errorf("redis not connected")
+	}
+	key := EventHeadcountKey(eventID)
+	return s.client.Del(ctx, key).Err()
+}
+
 var takeSeatScript = redis.NewScript(`
 local current = redis.call("GET", KEYS[1])
 if not current then

--- a/pkg/db/stores.go
+++ b/pkg/db/stores.go
@@ -10,6 +10,7 @@ import (
 type RedisStore interface {
 	SetEventHeadcount(ctx context.Context, eventID string, capacity int) error
 	GetEventHeadcount(ctx context.Context, eventID string) (int, error)
+	DeleteEventHeadcount(ctx context.Context, eventID string) error
 	TryTakeEventSeat(ctx context.Context, eventID string) (bool, error)
 	ReleaseEventSeat(ctx context.Context, eventID string) error
 	IsUserRegisteredForEvent(ctx context.Context, eventID string, userID string) (bool, error)

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"context"
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
 	"github.com/SCE-Development/SCEvents/pkg/models"
@@ -127,6 +128,8 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 		return
 	}
 
+	// max_attendees == -1 means the event has unlimited attendees,
+	// so we skip Redis headcount tracking for that case.
 	if createdEvent.MaxAttendees != -1 {
 		if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), createdEvent.ID, createdEvent.MaxAttendees); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -170,6 +173,43 @@ func (h *EventHandler) DeleteEventByID(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"message": "event deleted successfully",
 	})
+}
+
+// syncMaxAttendeesHeadcount keeps Redis headcount consistent after max_attendees changes.
+func (h *EventHandler) syncMaxAttendeesHeadcount(ctx context.Context, id string, existingEvent *models.Event, fields map[string]interface{}) error {
+	maxAttendees, ok := fields["max_attendees"]
+	if !ok {
+		return nil
+	}
+
+	newMax, ok := maxAttendees.(float64)
+	if !ok {
+		return nil
+	}
+
+	newMaxInt := int(newMax)
+
+	switch {
+	case newMaxInt == -1:
+		return h.stores.Redis.DeleteEventHeadcount(ctx, id)
+
+	case existingEvent.MaxAttendees == -1:
+		return h.stores.Redis.SetEventHeadcount(ctx, id, newMaxInt)
+
+	default:
+		currentRemaining, err := h.stores.Redis.GetEventHeadcount(ctx, id)
+		if err != nil {
+			currentRemaining = existingEvent.MaxAttendees
+		}
+
+		seatsTaken := existingEvent.MaxAttendees - currentRemaining
+		newRemaining := newMaxInt - seatsTaken
+		if newRemaining < 0 {
+			newRemaining = 0
+		}
+
+		return h.stores.Redis.SetEventHeadcount(ctx, id, newRemaining)
+	}
 }
 
 // updates an event by ID (partial update)
@@ -252,50 +292,11 @@ func (h *EventHandler) UpdateEventByID(c *gin.Context) {
 
 	// If max_attendees was updated, sync the headcount in Redis
 	// accounting for seats already given out
-	if maxAttendees, ok := fields["max_attendees"]; ok {
-		if newMax, ok := maxAttendees.(float64); ok {
-			newMaxInt := int(newMax)
-			switch {
-				// finite -> unlimited
-				case newMaxInt == -1:
-					if err := h.stores.Redis.DeleteEventHeadcount(c.Request.Context(), id); err != nil {
-						c.JSON(http.StatusInternalServerError, gin.H{
-							"error": "event updated but failed to clear headcount in Redis",
-						})
-						return
-					}
-	
-				// unlimited -> finite
-				case existingEvent.MaxAttendees == -1:
-					if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), id, newMaxInt); err != nil {
-						c.JSON(http.StatusInternalServerError, gin.H{
-							"error": "event updated but failed to initialize headcount in Redis",
-						})
-						return
-					}
-	
-				// finite -> finite
-				default:
-					currentRemaining, err := h.stores.Redis.GetEventHeadcount(c.Request.Context(), id)
-					if err != nil {
-						// If Redis key doesn't exist yet, assume no seats have been taken
-						currentRemaining = existingEvent.MaxAttendees
-					}
-	
-					seatsTaken := existingEvent.MaxAttendees - currentRemaining
-					newRemaining := newMaxInt - seatsTaken
-					if newRemaining < 0 {
-						newRemaining = 0
-					}
-	
-					if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), id, newRemaining); err != nil {
-						c.JSON(http.StatusInternalServerError, gin.H{
-							"error": "event updated but failed to sync headcount in Redis",
-						})
-						return
-					}
-			}
-		}
+	if err := h.syncMaxAttendeesHeadcount(c.Request.Context(), id, existingEvent, fields); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "event updated but failed to sync headcount in Redis",
+		})
+		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -127,11 +127,13 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 		return
 	}
 
-	if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), createdEvent.ID, createdEvent.MaxAttendees); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "failed to store event headcount",
-		})
-		return
+	if createdEvent.MaxAttendees != -1 {
+		if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), createdEvent.ID, createdEvent.MaxAttendees); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to store event headcount",
+			})
+			return
+		}
 	}
 
 	c.JSON(http.StatusCreated, createdEvent)
@@ -252,27 +254,46 @@ func (h *EventHandler) UpdateEventByID(c *gin.Context) {
 	// accounting for seats already given out
 	if maxAttendees, ok := fields["max_attendees"]; ok {
 		if newMax, ok := maxAttendees.(float64); ok {
-			// Get current remaining seats from Redis
-			currentRemaining, err := h.stores.Redis.GetEventHeadcount(c.Request.Context(), id)
-			if err != nil {
-				// If Redis key doesn't exist yet, no seats have been taken
-				currentRemaining = existingEvent.MaxAttendees
-			}
-
-			// Calculate how many seats have already been given out
-			seatsTaken := existingEvent.MaxAttendees - currentRemaining
-
-			// Set the new headcount: new max minus seats already taken
-			newRemaining := int(newMax) - seatsTaken
-			if newRemaining < 0 {
-				newRemaining = 0
-			}
-
-			if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), id, newRemaining); err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": "event updated but failed to sync headcount in Redis",
-				})
-				return
+			newMaxInt := int(newMax)
+			switch {
+				// finite -> unlimited
+				case newMaxInt == -1:
+					if err := h.stores.Redis.DeleteEventHeadcount(c.Request.Context(), id); err != nil {
+						c.JSON(http.StatusInternalServerError, gin.H{
+							"error": "event updated but failed to clear headcount in Redis",
+						})
+						return
+					}
+	
+				// unlimited -> finite
+				case existingEvent.MaxAttendees == -1:
+					if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), id, newMaxInt); err != nil {
+						c.JSON(http.StatusInternalServerError, gin.H{
+							"error": "event updated but failed to initialize headcount in Redis",
+						})
+						return
+					}
+	
+				// finite -> finite
+				default:
+					currentRemaining, err := h.stores.Redis.GetEventHeadcount(c.Request.Context(), id)
+					if err != nil {
+						// If Redis key doesn't exist yet, assume no seats have been taken
+						currentRemaining = existingEvent.MaxAttendees
+					}
+	
+					seatsTaken := existingEvent.MaxAttendees - currentRemaining
+					newRemaining := newMaxInt - seatsTaken
+					if newRemaining < 0 {
+						newRemaining = 0
+					}
+	
+					if err := h.stores.Redis.SetEventHeadcount(c.Request.Context(), id, newRemaining); err != nil {
+						c.JSON(http.StatusInternalServerError, gin.H{
+							"error": "event updated but failed to sync headcount in Redis",
+						})
+						return
+					}
 			}
 		}
 	}

--- a/pkg/handlers/event_test.go
+++ b/pkg/handlers/event_test.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SCE-Development/SCEvents/pkg/db"
+	"github.com/SCE-Development/SCEvents/pkg/models"
+)
+
+type mockRedisStore struct {
+	setCalled    bool
+	setCapacity  int
+	setErr       error
+
+	getCalled    bool
+	getRemaining int
+	getErr       error
+
+	deleteCalled bool
+	deleteErr    error
+}
+
+func (m *mockRedisStore) SetEventHeadcount(_ context.Context, _ string, capacity int) error {
+	m.setCalled = true
+	m.setCapacity = capacity
+	return m.setErr
+}
+
+func (m *mockRedisStore) GetEventHeadcount(_ context.Context, _ string) (int, error) {
+	m.getCalled = true
+	return m.getRemaining, m.getErr
+}
+
+func (m *mockRedisStore) DeleteEventHeadcount(_ context.Context, _ string) error {
+	m.deleteCalled = true
+	return m.deleteErr
+}
+
+func (m *mockRedisStore) TryTakeEventSeat(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func (m *mockRedisStore) ReleaseEventSeat(context.Context, string) error {
+	return nil
+}
+
+func (m *mockRedisStore) IsUserRegisteredForEvent(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (m *mockRedisStore) Close() error {
+	return nil
+}
+
+func newTestHandler(redis db.RedisStore) *EventHandler {
+	return &EventHandler{
+		stores: &db.Stores{
+			Redis: redis,
+		},
+	}
+}
+
+func TestSyncMaxAttendeesHeadcount_FiniteToUnlimited(t *testing.T) {
+	redis := &mockRedisStore{}
+	h := newTestHandler(redis)
+
+	existing := &models.Event{MaxAttendees: 10}
+	fields := map[string]interface{}{"max_attendees": float64(-1)}
+
+	err := h.syncMaxAttendeesHeadcount(context.Background(), "event-1", existing, fields)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !redis.deleteCalled {
+		t.Fatalf("expected DeleteEventHeadcount to be called")
+	}
+	if redis.setCalled {
+		t.Fatalf("did not expect SetEventHeadcount to be called")
+	}
+}
+
+func TestSyncMaxAttendeesHeadcount_UnlimitedToFinite(t *testing.T) {
+	redis := &mockRedisStore{}
+	h := newTestHandler(redis)
+
+	existing := &models.Event{MaxAttendees: -1}
+	fields := map[string]interface{}{"max_attendees": float64(25)}
+
+	err := h.syncMaxAttendeesHeadcount(context.Background(), "event-2", existing, fields)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !redis.setCalled {
+		t.Fatalf("expected SetEventHeadcount to be called")
+	}
+	if redis.setCapacity != 25 {
+		t.Fatalf("expected capacity 25, got %d", redis.setCapacity)
+	}
+	if redis.deleteCalled {
+		t.Fatalf("did not expect DeleteEventHeadcount to be called")
+	}
+}
+
+func TestSyncMaxAttendeesHeadcount_FiniteToFinite(t *testing.T) {
+	redis := &mockRedisStore{
+		getRemaining: 7, // existing max 10 => 3 seats taken
+	}
+	h := newTestHandler(redis)
+
+	existing := &models.Event{MaxAttendees: 10}
+	fields := map[string]interface{}{"max_attendees": float64(12)}
+
+	err := h.syncMaxAttendeesHeadcount(context.Background(), "event-3", existing, fields)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !redis.getCalled {
+		t.Fatalf("expected GetEventHeadcount to be called")
+	}
+	if !redis.setCalled {
+		t.Fatalf("expected SetEventHeadcount to be called")
+	}
+	if redis.setCapacity != 9 { // new max 12 - 3 seats taken
+		t.Fatalf("expected remaining capacity 9, got %d", redis.setCapacity)
+	}
+}

--- a/pkg/registration/consumer.go
+++ b/pkg/registration/consumer.go
@@ -100,16 +100,22 @@ func (c *Consumer) processKafkaMessage(ctx context.Context, raw []byte) error {
 		return c.stores.Mongo.MarkRegistrationRejected(ctx, msg.RequestID, models.ReasonDuplicateUser)
 	}
 
-	ok, err := c.stores.Redis.TryTakeEventSeat(ctx, msg.EventID)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return c.stores.Mongo.MarkRegistrationRejected(ctx, msg.RequestID, models.ReasonCapacityFull)
+	seatTaken := false
+	if ev.MaxAttendees != -1 {
+		ok, err := c.stores.Redis.TryTakeEventSeat(ctx, msg.EventID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return c.stores.Mongo.MarkRegistrationRejected(ctx, msg.RequestID, models.ReasonCapacityFull)
+		}
+		seatTaken = true
 	}
 
 	if err := c.stores.Mongo.MarkRegistrationAccepted(ctx, msg.RequestID); err != nil {
-		_ = c.stores.Redis.ReleaseEventSeat(ctx, msg.EventID)
+		if seatTaken {
+			_ = c.stores.Redis.ReleaseEventSeat(ctx, msg.EventID)
+		}
 		return err
 	}
 

--- a/pkg/registration/consumer_test.go
+++ b/pkg/registration/consumer_test.go
@@ -72,6 +72,9 @@ func (m *mockRedisStore) SetEventHeadcount(_ context.Context, _ string, _ int) e
 func (m *mockRedisStore) GetEventHeadcount(_ context.Context, _ string) (int, error) {
 	return 0, nil
 }
+func (m *mockRedisStore) DeleteEventHeadcount(ctx context.Context, eventID string) error {
+	return nil
+}
 func (m *mockRedisStore) TryTakeEventSeat(_ context.Context, _ string) (bool, error) {
 	return m.seatAvailable, m.seatErr
 }


### PR DESCRIPTION
Closes #71 
- skip writing event headcount to Redis for unlimited events
- add Redis headcount deletion support for events that become unlimited
- update event PATCH logic to correctly handle:
  - finite -> unlimited
  - unlimited -> finite
  - finite -> finite
- update Kafka registration consumer to skip Redis seat-taking for unlimited events

Update:
- add unit tests for max-attendees headcount transition logic
