### PR TITLE
Fix Kafka registration consumer Mongo store wiring

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -47,8 +47,14 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	redisStore := db.NewRedisStore(db.RedisClient())
+	mongoStore := db.NewMongoStore(
+		db.GetEventsCollection(),
+		db.GetRegistrationsCollection(),
+	)
+
 	stores := &db.Stores{
 		Redis: redisStore,
+		Mongo: mongoStore,
 	}
 
 	producer := registration.NewProducer(


### PR DESCRIPTION
### Problem
Registration requests could remain stuck in `pending` because the Kafka consumer was missing a wired Mongo store in shared backend stores. As a result, async processing could not read or update registrations and events.

### Changes
- initialized Mongo store using:
  - `db.GetEventsCollection()`
  - `db.GetRegistrationsCollection()`
- attached Mongo store to shared `db.Stores` in `main.go`
- wired Kafka consumer to use shared stores for registration processing

### Proof
Successful registration processing result:
```json
{"created_at":"2026-04-25T02:03:54.963Z","decision_reason":"","event_id":"test-event-1","processed_at":"2026-04-25T02:03:55.989Z","request_id":"2cd5ef8cdcda0feda456a85d75b51cec","status":"accepted","updated_at":"2026-04-25T02:03:55.989Z"}           
```

### Verification
- built server successfully with:
```bash
go build ./cmd/server
```
- ran local backend against Docker Mongo, Redis, and Kafka
- created a test event
- submitted registration requests through the API
- confirmed Kafka consumer processed queued messages
- confirmed request status transitions from pending to accepted
- confirmed capacity logic still works when seats are unavailable