### PR TITLE
Block registration for closed events

### DIFF
--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -330,6 +330,13 @@ func (h *EventHandler) RegisterForEvent(producer *registration.Producer) gin.Han
 			return
 		}
 
+		if ev.Status == models.StatusClosed {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "registration is closed for this event",
+			})
+			return
+		}
+
 		if ev.IsAdmin(payload.Registrant.UserID) {
 			c.JSON(http.StatusForbidden, gin.H{
 				"error": "event admins cannot register for their own event",

--- a/pkg/models/registration.go
+++ b/pkg/models/registration.go
@@ -19,6 +19,7 @@ const (
 	ReasonInvalidPayload   DecisionReason = "invalid_payload"
 	ReasonAlreadyProcessed DecisionReason = "already_processed"
 	ReasonInternalError    DecisionReason = "internal_error"
+	ReasonEventClosed      DecisionReason = "event_closed"
 )
 
 type Registrant struct {

--- a/pkg/registration/consumer.go
+++ b/pkg/registration/consumer.go
@@ -80,12 +80,16 @@ func (c *Consumer) processKafkaMessage(ctx context.Context, raw []byte) error {
 		return nil
 	}
 
-	_, err = c.stores.Mongo.GetEventByID(ctx, msg.EventID)
+	ev, err := c.stores.Mongo.GetEventByID(ctx, msg.EventID)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return c.stores.Mongo.MarkRegistrationRejected(ctx, msg.RequestID, models.ReasonEventNotFound)
 		}
 		return err
+	}
+
+	if ev.Status == models.StatusClosed {
+		return c.stores.Mongo.MarkRegistrationRejected(ctx, msg.RequestID, models.ReasonEventClosed)
 	}
 
 	duplicate, err := c.stores.Mongo.HasAcceptedRegistration(ctx, msg.EventID, msg.UserID)

--- a/pkg/registration/consumer_test.go
+++ b/pkg/registration/consumer_test.go
@@ -239,3 +239,25 @@ func TestProcessKafkaMessage_AcceptFailsReleasesSeat(t *testing.T) {
 		t.Fatal("expected ReleaseEventSeat to be called when accept fails")
 	}
 }
+
+func TestProcessKafkaMessage_EventClosed(t *testing.T) {
+	mongoMock := &mockMongoStore{
+		registration: &models.RegistrationRequest{
+			RequestID: "req-1",
+			Status:    models.StatusPending,
+		},
+		event: &models.Event{
+			ID:     "event-1",
+			Status: models.StatusClosed,
+		},
+	}
+
+	c := newTestConsumer(mongoMock, &mockRedisStore{})
+	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
+	if err != nil {
+		t.Fatalf("expected nil (rejected), got %v", err)
+	}
+	if mongoMock.rejectedReason != models.ReasonEventClosed {
+		t.Fatalf("expected reason %s, got %s", models.ReasonEventClosed, mongoMock.rejectedReason)
+	}
+}


### PR DESCRIPTION
### Problem
- Users could register for events even when `status = closed`
- Kafka consumer could still process and potentially accept those registrations

### Changes
- Added validation in `RegisterForEvent` handler:
  - Reject requests when `event.status == closed`
- Added validation in Kafka consumer:
  - Reject pending registrations if event becomes closed before processing
- Introduced new rejection reason:
  - `event_closed`
- Added unit test:
  - `TestProcessKafkaMessage_EventClosed`

### Verification
#### Manual Testing
- Open event → registration accepted
- Full event → rejected (`capacity_full`)
- Closed event → blocked at API level

Example response:
```json
{"error":"registration is closed for this event"}
```

- Kafka consumer correctly rejects with:
   - `decision_reason = event_closed`

#### Automated Tests
```bash
go test ./...
```
All tests passing.