### PR TITLE
Add exportable mocks

### DIFF
--- a/pkg/db/event_test.go
+++ b/pkg/db/event_test.go
@@ -78,12 +78,12 @@ func TestGetEventByID(t *testing.T) {
 		store := NewMongoStore(mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
-			{"_id", "event-1"},
-			{"name", "Test Event"},
-			{"date", "2026-05-01"},
-			{"time", "10:00"},
-			{"location", "Room 101"},
-			{"max_attendees", int32(50)},
+			{Key: "_id", Value: "event-1"},
+			{Key: "name", Value: "Test Event"},
+			{Key: "date", Value: "2026-05-01"},
+			{Key: "time", Value: "10:00"},
+			{Key: "location", Value: "Room 101"},
+			{Key: "max_attendees", Value: int32(50)},
 		}))
 		result, err := store.GetEventByID(context.Background(), "event-1")
 		if err != nil {
@@ -113,7 +113,7 @@ func TestDeleteEventByID(t *testing.T) {
 
 	mt.Run("success", func(mt *mtest.T) {
 		store := NewMongoStore(mt.Coll, nil)
-		mt.AddMockResponses(bson.D{{"ok", 1}, {"n", int32(1)}})
+		mt.AddMockResponses(bson.D{{Key: "ok", Value: 1}, {Key: "n", Value: int32(1)}})
 		if err := store.DeleteEventByID(context.Background(), "event-1"); err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -121,7 +121,7 @@ func TestDeleteEventByID(t *testing.T) {
 
 	mt.Run("not found", func(mt *mtest.T) {
 		store := NewMongoStore(mt.Coll, nil)
-		mt.AddMockResponses(bson.D{{"ok", 1}, {"n", int32(0)}})
+		mt.AddMockResponses(bson.D{{Key: "ok", Value: 1}, {Key: "n", Value: int32(0)}})
 		err := store.DeleteEventByID(context.Background(), "nonexistent")
 		if err != mongo.ErrNoDocuments {
 			t.Fatalf("expected ErrNoDocuments, got %v", err)
@@ -135,9 +135,9 @@ func TestUpdateEventByID(t *testing.T) {
 	mt.Run("success", func(mt *mtest.T) {
 		store := NewMongoStore(mt.Coll, nil)
 		mt.AddMockResponses(bson.D{
-			{"ok", 1},
-			{"n", int32(1)},
-			{"nModified", int32(1)},
+			{Key: "ok", Value: 1},
+			{Key: "n", Value: int32(1)},
+			{Key: "nModified", Value: int32(1)},
 		})
 		err := store.UpdateEventByID(context.Background(), "event-1", map[string]interface{}{
 			"name": "Updated Name",
@@ -150,9 +150,9 @@ func TestUpdateEventByID(t *testing.T) {
 	mt.Run("not found", func(mt *mtest.T) {
 		store := NewMongoStore(mt.Coll, nil)
 		mt.AddMockResponses(bson.D{
-			{"ok", 1},
-			{"n", int32(0)},
-			{"nModified", int32(0)},
+			{Key: "ok", Value: 1},
+			{Key: "n", Value: int32(0)},
+			{Key: "nModified", Value: int32(0)},
 		})
 		err := store.UpdateEventByID(context.Background(), "nonexistent", map[string]interface{}{
 			"name": "Updated Name",
@@ -171,18 +171,18 @@ func TestGetEvents(t *testing.T) {
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch,
 			bson.D{
-				{"_id", "event-1"},
-				{"name", "Event One"},
-				{"date", "2026-05-01"},
-				{"time", "10:00"},
-				{"location", "Room 101"},
+				{Key: "_id", Value: "event-1"},
+				{Key: "name", Value: "Event One"},
+				{Key: "date", Value: "2026-05-01"},
+				{Key: "time", Value: "10:00"},
+				{Key: "location", Value: "Room 101"},
 			},
 			bson.D{
-				{"_id", "event-2"},
-				{"name", "Event Two"},
-				{"date", "2026-05-15"},
-				{"time", "14:00"},
-				{"location", "Room 202"},
+				{Key: "_id", Value: "event-2"},
+				{Key: "name", Value: "Event Two"},
+				{Key: "date", Value: "2026-05-15"},
+				{Key: "time", Value: "14:00"},
+				{Key: "location", Value: "Room 202"},
 			},
 		))
 		events, err := store.GetEvents(context.Background(), "2026-05-01", "2026-05-31")

--- a/pkg/db/registration_test.go
+++ b/pkg/db/registration_test.go
@@ -48,13 +48,13 @@ func TestGetRegistrationByID(t *testing.T) {
 		store := NewMongoStore(nil, mt.Coll)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
-			{"_id", "req-1"},
-			{"event_id", "event-1"},
-			{"status", "pending"},
-			{"registrant", bson.D{
-				{"name", "John Doe"},
-				{"email", "john@example.com"},
-				{"user_id", "user-1"},
+			{Key: "_id", Value: "req-1"},
+			{Key: "event_id", Value: "event-1"},
+			{Key: "status", Value: "pending"},
+			{Key: "registrant", Value: bson.D{
+				{Key: "name", Value: "John Doe"},
+				{Key: "email", Value: "john@example.com"},
+				{Key: "user_id", Value: "user-1"},
 			}},
 		}))
 		result, err := store.GetRegistrationByID(context.Background(), "req-1")
@@ -87,9 +87,9 @@ func TestHasAcceptedRegistration(t *testing.T) {
 		store := NewMongoStore(nil, mt.Coll)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
-			{"_id", "req-1"},
-			{"event_id", "event-1"},
-			{"status", "accepted"},
+			{Key: "_id", Value: "req-1"},
+			{Key: "event_id", Value: "event-1"},
+			{Key: "status", Value: "accepted"},
 		}))
 		exists, err := store.HasAcceptedRegistration(context.Background(), "event-1", "user-1")
 		if err != nil {
@@ -121,9 +121,9 @@ func TestHasPendingOrAcceptedRegistration(t *testing.T) {
 		store := NewMongoStore(nil, mt.Coll)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
-			{"_id", "req-1"},
-			{"event_id", "event-1"},
-			{"status", "pending"},
+			{Key: "_id", Value: "req-1"},
+			{Key: "event_id", Value: "event-1"},
+			{Key: "status", Value: "pending"},
 		}))
 		exists, err := store.HasPendingOrAcceptedRegistration(context.Background(), "event-1", "user-1")
 		if err != nil {
@@ -154,9 +154,9 @@ func TestMarkRegistrationAccepted(t *testing.T) {
 	mt.Run("success", func(mt *mtest.T) {
 		store := NewMongoStore(nil, mt.Coll)
 		mt.AddMockResponses(bson.D{
-			{"ok", 1},
-			{"n", int32(1)},
-			{"nModified", int32(1)},
+			{Key: "ok", Value: 1},
+			{Key: "n", Value: int32(1)},
+			{Key: "nModified", Value: int32(1)},
 		})
 		if err := store.MarkRegistrationAccepted(context.Background(), "req-1"); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -166,9 +166,9 @@ func TestMarkRegistrationAccepted(t *testing.T) {
 	mt.Run("not found", func(mt *mtest.T) {
 		store := NewMongoStore(nil, mt.Coll)
 		mt.AddMockResponses(bson.D{
-			{"ok", 1},
-			{"n", int32(0)},
-			{"nModified", int32(0)},
+			{Key: "ok", Value: 1},
+			{Key: "n", Value: int32(0)},
+			{Key: "nModified", Value: int32(0)},
 		})
 		err := store.MarkRegistrationAccepted(context.Background(), "nonexistent")
 		if err != mongo.ErrNoDocuments {
@@ -183,9 +183,9 @@ func TestMarkRegistrationRejected(t *testing.T) {
 	mt.Run("success", func(mt *mtest.T) {
 		store := NewMongoStore(nil, mt.Coll)
 		mt.AddMockResponses(bson.D{
-			{"ok", 1},
-			{"n", int32(1)},
-			{"nModified", int32(1)},
+			{Key: "ok", Value: 1},
+			{Key: "n", Value: int32(1)},
+			{Key: "nModified", Value: int32(1)},
 		})
 		if err := store.MarkRegistrationRejected(context.Background(), "req-1", models.ReasonCapacityFull); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -195,9 +195,9 @@ func TestMarkRegistrationRejected(t *testing.T) {
 	mt.Run("not found", func(mt *mtest.T) {
 		store := NewMongoStore(nil, mt.Coll)
 		mt.AddMockResponses(bson.D{
-			{"ok", 1},
-			{"n", int32(0)},
-			{"nModified", int32(0)},
+			{Key: "ok", Value: 1},
+			{Key: "n", Value: int32(0)},
+			{Key: "nModified", Value: int32(0)},
 		})
 		err := store.MarkRegistrationRejected(context.Background(), "nonexistent", models.ReasonCapacityFull)
 		if err != mongo.ErrNoDocuments {

--- a/pkg/handlers/event_test.go
+++ b/pkg/handlers/event_test.go
@@ -5,53 +5,9 @@ import (
 	"testing"
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
+	"github.com/SCE-Development/SCEvents/pkg/mocks"
 	"github.com/SCE-Development/SCEvents/pkg/models"
 )
-
-type mockRedisStore struct {
-	setCalled    bool
-	setCapacity  int
-	setErr       error
-
-	getCalled    bool
-	getRemaining int
-	getErr       error
-
-	deleteCalled bool
-	deleteErr    error
-}
-
-func (m *mockRedisStore) SetEventHeadcount(_ context.Context, _ string, capacity int) error {
-	m.setCalled = true
-	m.setCapacity = capacity
-	return m.setErr
-}
-
-func (m *mockRedisStore) GetEventHeadcount(_ context.Context, _ string) (int, error) {
-	m.getCalled = true
-	return m.getRemaining, m.getErr
-}
-
-func (m *mockRedisStore) DeleteEventHeadcount(_ context.Context, _ string) error {
-	m.deleteCalled = true
-	return m.deleteErr
-}
-
-func (m *mockRedisStore) TryTakeEventSeat(context.Context, string) (bool, error) {
-	return false, nil
-}
-
-func (m *mockRedisStore) ReleaseEventSeat(context.Context, string) error {
-	return nil
-}
-
-func (m *mockRedisStore) IsUserRegisteredForEvent(context.Context, string, string) (bool, error) {
-	return false, nil
-}
-
-func (m *mockRedisStore) Close() error {
-	return nil
-}
 
 func newTestHandler(redis db.RedisStore) *EventHandler {
 	return &EventHandler{
@@ -62,7 +18,7 @@ func newTestHandler(redis db.RedisStore) *EventHandler {
 }
 
 func TestSyncMaxAttendeesHeadcount_FiniteToUnlimited(t *testing.T) {
-	redis := &mockRedisStore{}
+	redis := &mocks.MockRedisStore{}
 	h := newTestHandler(redis)
 
 	existing := &models.Event{MaxAttendees: 10}
@@ -73,16 +29,16 @@ func TestSyncMaxAttendeesHeadcount_FiniteToUnlimited(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !redis.deleteCalled {
+	if !redis.DeleteCalled {
 		t.Fatalf("expected DeleteEventHeadcount to be called")
 	}
-	if redis.setCalled {
+	if redis.SetCalled {
 		t.Fatalf("did not expect SetEventHeadcount to be called")
 	}
 }
 
 func TestSyncMaxAttendeesHeadcount_UnlimitedToFinite(t *testing.T) {
-	redis := &mockRedisStore{}
+	redis := &mocks.MockRedisStore{}
 	h := newTestHandler(redis)
 
 	existing := &models.Event{MaxAttendees: -1}
@@ -93,20 +49,20 @@ func TestSyncMaxAttendeesHeadcount_UnlimitedToFinite(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !redis.setCalled {
+	if !redis.SetCalled {
 		t.Fatalf("expected SetEventHeadcount to be called")
 	}
-	if redis.setCapacity != 25 {
-		t.Fatalf("expected capacity 25, got %d", redis.setCapacity)
+	if redis.SetCapacity != 25 {
+		t.Fatalf("expected capacity 25, got %d", redis.SetCapacity)
 	}
-	if redis.deleteCalled {
+	if redis.DeleteCalled {
 		t.Fatalf("did not expect DeleteEventHeadcount to be called")
 	}
 }
 
 func TestSyncMaxAttendeesHeadcount_FiniteToFinite(t *testing.T) {
-	redis := &mockRedisStore{
-		getRemaining: 7, // existing max 10 => 3 seats taken
+	redis := &mocks.MockRedisStore{
+		GetRemaining: 7, // existing max 10 => 3 seats taken
 	}
 	h := newTestHandler(redis)
 
@@ -118,13 +74,13 @@ func TestSyncMaxAttendeesHeadcount_FiniteToFinite(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !redis.getCalled {
+	if !redis.GetCalled {
 		t.Fatalf("expected GetEventHeadcount to be called")
 	}
-	if !redis.setCalled {
+	if !redis.SetCalled {
 		t.Fatalf("expected SetEventHeadcount to be called")
 	}
-	if redis.setCapacity != 9 { // new max 12 - 3 seats taken
-		t.Fatalf("expected remaining capacity 9, got %d", redis.setCapacity)
+	if redis.SetCapacity != 9 { // new max 12 - 3 seats taken
+		t.Fatalf("expected remaining capacity 9, got %d", redis.SetCapacity)
 	}
 }

--- a/pkg/mocks/kafka.go
+++ b/pkg/mocks/kafka.go
@@ -1,0 +1,31 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/SCE-Development/SCEvents/pkg/models"
+)
+
+type MockKafkaProducer struct {
+	PublishedMessages []models.KafkaRegistrationMessage
+	PublishErr        error
+	CloseErr          error
+	Closed            bool
+}
+
+func (m *MockKafkaProducer) PublishRegistration(_ context.Context, requestID string, eventID string, userID string) error {
+	if m.PublishErr != nil {
+		return m.PublishErr
+	}
+	m.PublishedMessages = append(m.PublishedMessages, models.KafkaRegistrationMessage{
+		RequestID: requestID,
+		EventID:   eventID,
+		UserID:    userID,
+	})
+	return nil
+}
+
+func (m *MockKafkaProducer) Close() error {
+	m.Closed = true
+	return m.CloseErr
+}

--- a/pkg/mocks/mongo.go
+++ b/pkg/mocks/mongo.go
@@ -1,0 +1,54 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/SCE-Development/SCEvents/pkg/models"
+)
+
+type MockMongoStore struct {
+	Registration    *models.RegistrationRequest
+	RegistrationErr error
+	Event           *models.Event
+	EventErr        error
+	HasAccepted     bool
+	HasAcceptedErr  error
+	MarkAcceptedErr error
+	MarkRejectedErr error
+	RejectedReason  models.DecisionReason
+}
+
+func (m *MockMongoStore) GetEvents(_ context.Context, _, _ string) ([]models.Event, error) {
+	return nil, nil
+}
+func (m *MockMongoStore) GetEventByID(_ context.Context, _ string) (*models.Event, error) {
+	return m.Event, m.EventErr
+}
+func (m *MockMongoStore) CreateEvent(_ context.Context, e models.Event) (*models.Event, error) {
+	return &e, nil
+}
+func (m *MockMongoStore) DeleteEventByID(_ context.Context, _ string) error {
+	return nil
+}
+func (m *MockMongoStore) UpdateEventByID(_ context.Context, _ string, _ map[string]interface{}) error {
+	return nil
+}
+func (m *MockMongoStore) CreatePendingRegistration(_ context.Context, r models.RegistrationRequest) (*models.RegistrationRequest, error) {
+	return &r, nil
+}
+func (m *MockMongoStore) GetRegistrationByID(_ context.Context, _ string) (*models.RegistrationRequest, error) {
+	return m.Registration, m.RegistrationErr
+}
+func (m *MockMongoStore) HasAcceptedRegistration(_ context.Context, _, _ string) (bool, error) {
+	return m.HasAccepted, m.HasAcceptedErr
+}
+func (m *MockMongoStore) HasPendingOrAcceptedRegistration(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (m *MockMongoStore) MarkRegistrationAccepted(_ context.Context, _ string) error {
+	return m.MarkAcceptedErr
+}
+func (m *MockMongoStore) MarkRegistrationRejected(_ context.Context, _ string, reason models.DecisionReason) error {
+	m.RejectedReason = reason
+	return m.MarkRejectedErr
+}

--- a/pkg/mocks/redis.go
+++ b/pkg/mocks/redis.go
@@ -1,0 +1,50 @@
+package mocks
+
+import (
+	"context"
+)
+
+type MockRedisStore struct {
+	SeatAvailable bool
+	SeatErr       error
+	ReleaseCalled bool
+	ReleaseErr    error
+
+	SetCalled   bool
+	SetCapacity int
+	SetErr      error
+
+	GetCalled    bool
+	GetRemaining int
+	GetErr       error
+
+	DeleteCalled bool
+	DeleteErr    error
+}
+
+func (m *MockRedisStore) SetEventHeadcount(_ context.Context, _ string, capacity int) error {
+	m.SetCalled = true
+	m.SetCapacity = capacity
+	return m.SetErr
+}
+func (m *MockRedisStore) GetEventHeadcount(_ context.Context, _ string) (int, error) {
+	m.GetCalled = true
+	return m.GetRemaining, m.GetErr
+}
+func (m *MockRedisStore) DeleteEventHeadcount(ctx context.Context, eventID string) error {
+	m.DeleteCalled = true
+	return m.DeleteErr
+}
+func (m *MockRedisStore) TryTakeEventSeat(_ context.Context, _ string) (bool, error) {
+	return m.SeatAvailable, m.SeatErr
+}
+func (m *MockRedisStore) ReleaseEventSeat(_ context.Context, _ string) error {
+	m.ReleaseCalled = true
+	return m.ReleaseErr
+}
+func (m *MockRedisStore) IsUserRegisteredForEvent(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (m *MockRedisStore) Close() error {
+	return nil
+}

--- a/pkg/registration/consumer_test.go
+++ b/pkg/registration/consumer_test.go
@@ -8,86 +8,10 @@ import (
 	"time"
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
+	"github.com/SCE-Development/SCEvents/pkg/mocks"
 	"github.com/SCE-Development/SCEvents/pkg/models"
 	"go.mongodb.org/mongo-driver/mongo"
 )
-
-type mockMongoStore struct {
-	registration     *models.RegistrationRequest
-	registrationErr  error
-	event            *models.Event
-	eventErr         error
-	hasAccepted      bool
-	hasAcceptedErr   error
-	markAcceptedErr  error
-	markRejectedErr  error
-	rejectedReason   models.DecisionReason
-}
-
-func (m *mockMongoStore) GetEvents(_ context.Context, _, _ string) ([]models.Event, error) {
-	return nil, nil
-}
-func (m *mockMongoStore) GetEventByID(_ context.Context, _ string) (*models.Event, error) {
-	return m.event, m.eventErr
-}
-func (m *mockMongoStore) CreateEvent(_ context.Context, e models.Event) (*models.Event, error) {
-	return &e, nil
-}
-func (m *mockMongoStore) DeleteEventByID(_ context.Context, _ string) error {
-	return nil
-}
-func (m *mockMongoStore) UpdateEventByID(_ context.Context, _ string, _ map[string]interface{}) error {
-	return nil
-}
-func (m *mockMongoStore) CreatePendingRegistration(_ context.Context, r models.RegistrationRequest) (*models.RegistrationRequest, error) {
-	return &r, nil
-}
-func (m *mockMongoStore) GetRegistrationByID(_ context.Context, _ string) (*models.RegistrationRequest, error) {
-	return m.registration, m.registrationErr
-}
-func (m *mockMongoStore) HasAcceptedRegistration(_ context.Context, _, _ string) (bool, error) {
-	return m.hasAccepted, m.hasAcceptedErr
-}
-func (m *mockMongoStore) HasPendingOrAcceptedRegistration(_ context.Context, _, _ string) (bool, error) {
-	return false, nil
-}
-func (m *mockMongoStore) MarkRegistrationAccepted(_ context.Context, _ string) error {
-	return m.markAcceptedErr
-}
-func (m *mockMongoStore) MarkRegistrationRejected(_ context.Context, _ string, reason models.DecisionReason) error {
-	m.rejectedReason = reason
-	return m.markRejectedErr
-}
-
-type mockRedisStore struct {
-	seatAvailable  bool
-	seatErr        error
-	releaseCalled  bool
-	releaseErr     error
-}
-
-func (m *mockRedisStore) SetEventHeadcount(_ context.Context, _ string, _ int) error {
-	return nil
-}
-func (m *mockRedisStore) GetEventHeadcount(_ context.Context, _ string) (int, error) {
-	return 0, nil
-}
-func (m *mockRedisStore) DeleteEventHeadcount(ctx context.Context, eventID string) error {
-	return nil
-}
-func (m *mockRedisStore) TryTakeEventSeat(_ context.Context, _ string) (bool, error) {
-	return m.seatAvailable, m.seatErr
-}
-func (m *mockRedisStore) ReleaseEventSeat(_ context.Context, _ string) error {
-	m.releaseCalled = true
-	return m.releaseErr
-}
-func (m *mockRedisStore) IsUserRegisteredForEvent(_ context.Context, _, _ string) (bool, error) {
-	return false, nil
-}
-func (m *mockRedisStore) Close() error {
-	return nil
-}
 
 func validKafkaMessage() []byte {
 	msg := models.KafkaRegistrationMessage{
@@ -110,7 +34,7 @@ func newTestConsumer(mongoStore db.MongoStore, redisStore db.RedisStore) *Consum
 }
 
 func TestProcessKafkaMessage_InvalidJSON(t *testing.T) {
-	c := newTestConsumer(&mockMongoStore{}, &mockRedisStore{})
+	c := newTestConsumer(&mocks.MockMongoStore{}, &mocks.MockRedisStore{})
 	err := c.processKafkaMessage(context.Background(), []byte("not json"))
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
@@ -118,7 +42,7 @@ func TestProcessKafkaMessage_InvalidJSON(t *testing.T) {
 }
 
 func TestProcessKafkaMessage_MissingFields(t *testing.T) {
-	c := newTestConsumer(&mockMongoStore{}, &mockRedisStore{})
+	c := newTestConsumer(&mocks.MockMongoStore{}, &mocks.MockRedisStore{})
 	msg, _ := json.Marshal(models.KafkaRegistrationMessage{RequestID: "req-1"})
 	err := c.processKafkaMessage(context.Background(), msg)
 	if err == nil {
@@ -127,10 +51,10 @@ func TestProcessKafkaMessage_MissingFields(t *testing.T) {
 }
 
 func TestProcessKafkaMessage_RegistrationNotFound(t *testing.T) {
-	mongoMock := &mockMongoStore{
-		registrationErr: mongo.ErrNoDocuments,
+	mongoMock := &mocks.MockMongoStore{
+		RegistrationErr: mongo.ErrNoDocuments,
 	}
-	c := newTestConsumer(mongoMock, &mockRedisStore{})
+	c := newTestConsumer(mongoMock, &mocks.MockRedisStore{})
 	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
 	if !errors.Is(err, mongo.ErrNoDocuments) {
 		t.Fatalf("expected ErrNoDocuments, got %v", err)
@@ -138,13 +62,13 @@ func TestProcessKafkaMessage_RegistrationNotFound(t *testing.T) {
 }
 
 func TestProcessKafkaMessage_AlreadyProcessed(t *testing.T) {
-	mongoMock := &mockMongoStore{
-		registration: &models.RegistrationRequest{
+	mongoMock := &mocks.MockMongoStore{
+		Registration: &models.RegistrationRequest{
 			RequestID: "req-1",
 			Status:    models.StatusAccepted,
 		},
 	}
-	c := newTestConsumer(mongoMock, &mockRedisStore{})
+	c := newTestConsumer(mongoMock, &mocks.MockRedisStore{})
 	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
 	if err != nil {
 		t.Fatalf("expected nil (no-op) for already processed, got %v", err)
@@ -152,70 +76,70 @@ func TestProcessKafkaMessage_AlreadyProcessed(t *testing.T) {
 }
 
 func TestProcessKafkaMessage_EventNotFound(t *testing.T) {
-	mongoMock := &mockMongoStore{
-		registration: &models.RegistrationRequest{
+	mongoMock := &mocks.MockMongoStore{
+		Registration: &models.RegistrationRequest{
 			RequestID: "req-1",
 			Status:    models.StatusPending,
 		},
-		eventErr: mongo.ErrNoDocuments,
+		EventErr: mongo.ErrNoDocuments,
 	}
-	c := newTestConsumer(mongoMock, &mockRedisStore{})
+	c := newTestConsumer(mongoMock, &mocks.MockRedisStore{})
 	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
 	if err != nil {
 		t.Fatalf("expected nil (rejected), got %v", err)
 	}
-	if mongoMock.rejectedReason != models.ReasonEventNotFound {
-		t.Fatalf("expected reason %s, got %s", models.ReasonEventNotFound, mongoMock.rejectedReason)
+	if mongoMock.RejectedReason != models.ReasonEventNotFound {
+		t.Fatalf("expected reason %s, got %s", models.ReasonEventNotFound, mongoMock.RejectedReason)
 	}
 }
 
 func TestProcessKafkaMessage_DuplicateUser(t *testing.T) {
-	mongoMock := &mockMongoStore{
-		registration: &models.RegistrationRequest{
+	mongoMock := &mocks.MockMongoStore{
+		Registration: &models.RegistrationRequest{
 			RequestID: "req-1",
 			Status:    models.StatusPending,
 		},
-		event:       &models.Event{ID: "event-1"},
-		hasAccepted: true,
+		Event:       &models.Event{ID: "event-1"},
+		HasAccepted: true,
 	}
-	c := newTestConsumer(mongoMock, &mockRedisStore{})
+	c := newTestConsumer(mongoMock, &mocks.MockRedisStore{})
 	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
 	if err != nil {
 		t.Fatalf("expected nil (rejected), got %v", err)
 	}
-	if mongoMock.rejectedReason != models.ReasonDuplicateUser {
-		t.Fatalf("expected reason %s, got %s", models.ReasonDuplicateUser, mongoMock.rejectedReason)
+	if mongoMock.RejectedReason != models.ReasonDuplicateUser {
+		t.Fatalf("expected reason %s, got %s", models.ReasonDuplicateUser, mongoMock.RejectedReason)
 	}
 }
 
 func TestProcessKafkaMessage_CapacityFull(t *testing.T) {
-	mongoMock := &mockMongoStore{
-		registration: &models.RegistrationRequest{
+	mongoMock := &mocks.MockMongoStore{
+		Registration: &models.RegistrationRequest{
 			RequestID: "req-1",
 			Status:    models.StatusPending,
 		},
-		event: &models.Event{ID: "event-1"},
+		Event: &models.Event{ID: "event-1"},
 	}
-	redisMock := &mockRedisStore{seatAvailable: false}
+	redisMock := &mocks.MockRedisStore{SeatAvailable: false}
 	c := newTestConsumer(mongoMock, redisMock)
 	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
 	if err != nil {
 		t.Fatalf("expected nil (rejected), got %v", err)
 	}
-	if mongoMock.rejectedReason != models.ReasonCapacityFull {
-		t.Fatalf("expected reason %s, got %s", models.ReasonCapacityFull, mongoMock.rejectedReason)
+	if mongoMock.RejectedReason != models.ReasonCapacityFull {
+		t.Fatalf("expected reason %s, got %s", models.ReasonCapacityFull, mongoMock.RejectedReason)
 	}
 }
 
 func TestProcessKafkaMessage_HappyPath(t *testing.T) {
-	mongoMock := &mockMongoStore{
-		registration: &models.RegistrationRequest{
+	mongoMock := &mocks.MockMongoStore{
+		Registration: &models.RegistrationRequest{
 			RequestID: "req-1",
 			Status:    models.StatusPending,
 		},
-		event: &models.Event{ID: "event-1"},
+		Event: &models.Event{ID: "event-1"},
 	}
-	redisMock := &mockRedisStore{seatAvailable: true}
+	redisMock := &mocks.MockRedisStore{SeatAvailable: true}
 	c := newTestConsumer(mongoMock, redisMock)
 	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
 	if err != nil {
@@ -224,43 +148,43 @@ func TestProcessKafkaMessage_HappyPath(t *testing.T) {
 }
 
 func TestProcessKafkaMessage_AcceptFailsReleasesSeat(t *testing.T) {
-	mongoMock := &mockMongoStore{
-		registration: &models.RegistrationRequest{
+	mongoMock := &mocks.MockMongoStore{
+		Registration: &models.RegistrationRequest{
 			RequestID: "req-1",
 			Status:    models.StatusPending,
 		},
-		event:           &models.Event{ID: "event-1"},
-		markAcceptedErr: errors.New("mongo write failure"),
+		Event:           &models.Event{ID: "event-1"},
+		MarkAcceptedErr: errors.New("mongo write failure"),
 	}
-	redisMock := &mockRedisStore{seatAvailable: true}
+	redisMock := &mocks.MockRedisStore{SeatAvailable: true}
 	c := newTestConsumer(mongoMock, redisMock)
 	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
 	if err == nil {
 		t.Fatal("expected error when accept fails")
 	}
-	if !redisMock.releaseCalled {
+	if !redisMock.ReleaseCalled {
 		t.Fatal("expected ReleaseEventSeat to be called when accept fails")
 	}
 }
 
 func TestProcessKafkaMessage_EventClosed(t *testing.T) {
-	mongoMock := &mockMongoStore{
-		registration: &models.RegistrationRequest{
+	mongoMock := &mocks.MockMongoStore{
+		Registration: &models.RegistrationRequest{
 			RequestID: "req-1",
 			Status:    models.StatusPending,
 		},
-		event: &models.Event{
+		Event: &models.Event{
 			ID:     "event-1",
 			Status: models.StatusClosed,
 		},
 	}
 
-	c := newTestConsumer(mongoMock, &mockRedisStore{})
+	c := newTestConsumer(mongoMock, &mocks.MockRedisStore{})
 	err := c.processKafkaMessage(context.Background(), validKafkaMessage())
 	if err != nil {
 		t.Fatalf("expected nil (rejected), got %v", err)
 	}
-	if mongoMock.rejectedReason != models.ReasonEventClosed {
-		t.Fatalf("expected reason %s, got %s", models.ReasonEventClosed, mongoMock.rejectedReason)
+	if mongoMock.RejectedReason != models.ReasonEventClosed {
+		t.Fatalf("expected reason %s, got %s", models.ReasonEventClosed, mongoMock.RejectedReason)
 	}
 }

--- a/pkg/registration/producer_test.go
+++ b/pkg/registration/producer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SCE-Development/SCEvents/pkg/mocks"
 	"github.com/SCE-Development/SCEvents/pkg/models"
 )
 
@@ -101,47 +102,23 @@ func TestProducerClose(t *testing.T) {
 	})
 }
 
-type mockKafkaProducer struct {
-	publishedMessages []models.KafkaRegistrationMessage
-	publishErr        error
-	closeErr          error
-	closed            bool
-}
-
-func (m *mockKafkaProducer) PublishRegistration(_ context.Context, requestID string, eventID string, userID string) error {
-	if m.publishErr != nil {
-		return m.publishErr
-	}
-	m.publishedMessages = append(m.publishedMessages, models.KafkaRegistrationMessage{
-		RequestID: requestID,
-		EventID:   eventID,
-		UserID:    userID,
-	})
-	return nil
-}
-
-func (m *mockKafkaProducer) Close() error {
-	m.closed = true
-	return m.closeErr
-}
-
 func TestMockKafkaProducer(t *testing.T) {
 	t.Run("records published messages", func(t *testing.T) {
-		mock := &mockKafkaProducer{}
+		mock := &mocks.MockKafkaProducer{}
 		err := mock.PublishRegistration(context.Background(), "req-1", "event-1", "user-1")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if len(mock.publishedMessages) != 1 {
-			t.Fatalf("expected 1 message, got %d", len(mock.publishedMessages))
+		if len(mock.PublishedMessages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(mock.PublishedMessages))
 		}
-		if mock.publishedMessages[0].RequestID != "req-1" {
-			t.Fatalf("expected request ID req-1, got %s", mock.publishedMessages[0].RequestID)
+		if mock.PublishedMessages[0].RequestID != "req-1" {
+			t.Fatalf("expected request ID req-1, got %s", mock.PublishedMessages[0].RequestID)
 		}
 	})
 
 	t.Run("returns configured error", func(t *testing.T) {
-		mock := &mockKafkaProducer{publishErr: errors.New("broker down")}
+		mock := &mocks.MockKafkaProducer{PublishErr: errors.New("broker down")}
 		err := mock.PublishRegistration(context.Background(), "req-1", "event-1", "user-1")
 		if err == nil {
 			t.Fatal("expected error")
@@ -149,18 +126,18 @@ func TestMockKafkaProducer(t *testing.T) {
 		if err.Error() != "broker down" {
 			t.Fatalf("expected 'broker down', got %q", err.Error())
 		}
-		if len(mock.publishedMessages) != 0 {
-			t.Fatalf("expected 0 messages on error, got %d", len(mock.publishedMessages))
+		if len(mock.PublishedMessages) != 0 {
+			t.Fatalf("expected 0 messages on error, got %d", len(mock.PublishedMessages))
 		}
 	})
 
 	t.Run("close tracks state", func(t *testing.T) {
-		mock := &mockKafkaProducer{}
-		if mock.closed {
+		mock := &mocks.MockKafkaProducer{}
+		if mock.Closed {
 			t.Fatal("expected closed=false before Close()")
 		}
 		_ = mock.Close()
-		if !mock.closed {
+		if !mock.Closed {
 			t.Fatal("expected closed=true after Close()")
 		}
 	})


### PR DESCRIPTION
**CHANGES**
- adds a new `mocks` directory containing mocks for each of the three core services in SCEvents (Redis, Kafka, Mongo)
- updated tests across project to utilize mock services if needed (ex. tests from #71)

**TESTING**
- CI passes which runs `go test`

resolves #99