### PR TITLE
Add admin event attendance count

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,6 +29,9 @@ func main() {
 	if err := db.InitWaitlistIndexes(); err != nil {
 		log.Fatalf("Failed to initialize waitlist indexes: %v", err)
 	}
+	if err := db.InitRegistrationIndexes(); err != nil {
+		log.Fatalf("Failed to initialize registration indexes: %v", err)
+	}
 	defer func() {
 		if err := db.Disconnect(); err != nil {
 			log.Printf("Error disconnecting MongoDB: %v", err)
@@ -102,6 +105,7 @@ func main() {
 		protected.Use(middleware.RequireAuth(middleware.MembershipStateNonMember, cfg.ClientAPIURL))
 		{
 			protected.POST("/", eventHandler.CreateEvent)
+			protected.GET("/:id/attendance", eventHandler.GetEventAttendanceSummary)
 			protected.POST("/:id/register", eventHandler.RegisterForEvent(producer))
 			protected.POST("/:id/waitlist", eventHandler.JoinEventWaitlist)
 			protected.DELETE("/:id", eventHandler.DeleteEventByID)

--- a/pkg/db/redis.go
+++ b/pkg/db/redis.go
@@ -96,12 +96,30 @@ if not current then
 end
 
 current = tonumber(current)
-if current <= 0 then
+if current < 0 then
+	return 1
+end
+
+if current == 0 then
 	return 0
 end
 
 redis.call("DECR", KEYS[1])
 return 1
+`)
+
+var releaseSeatScript = redis.NewScript(`
+local current = redis.call("GET", KEYS[1])
+if not current then
+	return -2
+end
+
+current = tonumber(current)
+if current < 0 then
+	return current
+end
+
+return redis.call("INCR", KEYS[1])
 `)
 
 func (s *redisStore) TryTakeEventSeat(ctx context.Context, eventID string) (bool, error) {
@@ -130,7 +148,7 @@ func (s *redisStore) ReleaseEventSeat(ctx context.Context, eventID string) error
 		return fmt.Errorf("redis not connected")
 	}
 	key := EventHeadcountKey(eventID)
-	return s.client.Incr(ctx, key).Err()
+	return releaseSeatScript.Run(ctx, s.client, []string{key}).Err()
 }
 
 func (s *redisStore) IsUserRegisteredForEvent(ctx context.Context, eventID string, userID string) (bool, error) {

--- a/pkg/db/redis_test.go
+++ b/pkg/db/redis_test.go
@@ -97,6 +97,30 @@ func TestTryTakeEventSeatFullEvent(t *testing.T) {
 	}
 }
 
+func TestTryTakeEventSeatUnlimitedEvent(t *testing.T) {
+	store := newTestRedisStore(t)
+
+	if err := store.SetEventHeadcount(context.Background(), "event-1", -1); err != nil {
+		t.Fatalf("SetEventHeadcount failed: %v", err)
+	}
+
+	ok, err := store.TryTakeEventSeat(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("TryTakeEventSeat failed: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected seat acquisition to succeed for unlimited event")
+	}
+
+	remaining, err := store.GetEventHeadcount(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("GetEventHeadcount failed: %v", err)
+	}
+	if remaining != -1 {
+		t.Fatalf("expected remaining -1, got %d", remaining)
+	}
+}
+
 func TestTryTakeEventSeatMissingHeadcount(t *testing.T) {
 	store := newTestRedisStore(t)
 
@@ -128,6 +152,25 @@ func TestReleaseEventSeat(t *testing.T) {
 	}
 	if remaining != 2 {
 		t.Fatalf("expected remaining 2, got %d", remaining)
+	}
+}
+
+func TestReleaseEventSeatUnlimitedEvent(t *testing.T) {
+	store := newTestRedisStore(t)
+
+	if err := store.SetEventHeadcount(context.Background(), "event-1", -1); err != nil {
+		t.Fatalf("SetEventHeadcount failed: %v", err)
+	}
+	if err := store.ReleaseEventSeat(context.Background(), "event-1"); err != nil {
+		t.Fatalf("ReleaseEventSeat failed: %v", err)
+	}
+
+	remaining, err := store.GetEventHeadcount(context.Background(), "event-1")
+	if err != nil {
+		t.Fatalf("GetEventHeadcount failed: %v", err)
+	}
+	if remaining != -1 {
+		t.Fatalf("expected remaining -1, got %d", remaining)
 	}
 }
 

--- a/pkg/db/registration.go
+++ b/pkg/db/registration.go
@@ -7,10 +7,27 @@ import (
 	"github.com/SCE-Development/SCEvents/pkg/models"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func GetRegistrationsCollection() *mongo.Collection {
 	return Database().Collection("registrations")
+}
+
+func InitRegistrationIndexes() error {
+	coll := GetRegistrationsCollection()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "event_id", Value: 1},
+			{Key: "status", Value: 1},
+		},
+		Options: options.Index().SetName("event_id_status"),
+	})
+	return err
 }
 
 // CreatePendingRegistration inserts a new registration request with status "pending" before async processing
@@ -49,6 +66,18 @@ func GetRegistrationByID(requestID string) (*models.RegistrationRequest, error) 
 	}
 
 	return &r, nil
+}
+
+func CountAcceptedRegistrationsForEvent(eventID string) (int64, error) {
+	coll := GetRegistrationsCollection()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	return coll.CountDocuments(ctx, bson.M{
+		"event_id": eventID,
+		"status":   models.StatusAccepted,
+	})
 }
 
 // HasAcceptedRegistration checks if a user already has an accepted registration for an event
@@ -195,6 +224,13 @@ func (s *mongoStore) GetRegistrationByID(ctx context.Context, requestID string) 
 		return nil, err
 	}
 	return &r, nil
+}
+
+func (s *mongoStore) CountAcceptedRegistrationsForEvent(ctx context.Context, eventID string) (int64, error) {
+	return s.registrations.CountDocuments(ctx, bson.M{
+		"event_id": eventID,
+		"status":   models.StatusAccepted,
+	})
 }
 
 func (s *mongoStore) HasAcceptedRegistration(ctx context.Context, eventID, userID string) (bool, error) {

--- a/pkg/db/registration_test.go
+++ b/pkg/db/registration_test.go
@@ -80,6 +80,40 @@ func TestGetRegistrationByID(t *testing.T) {
 	})
 }
 
+func TestCountAcceptedRegistrationsForEvent(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("returns count", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
+			{Key: "n", Value: int32(2)},
+		}))
+		count, err := store.CountAcceptedRegistrationsForEvent(context.Background(), "event-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if count != 2 {
+			t.Fatalf("expected count 2, got %d", count)
+		}
+	})
+
+	mt.Run("returns zero", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
+			{Key: "n", Value: int32(0)},
+		}))
+		count, err := store.CountAcceptedRegistrationsForEvent(context.Background(), "event-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("expected count 0, got %d", count)
+		}
+	})
+}
+
 func TestHasAcceptedRegistration(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 

--- a/pkg/db/stores.go
+++ b/pkg/db/stores.go
@@ -30,6 +30,7 @@ type MongoStore interface {
 	UpdateEventByID(ctx context.Context, id string, fields map[string]interface{}) error
 	CreatePendingRegistration(ctx context.Context, r models.RegistrationRequest) (*models.RegistrationRequest, error)
 	GetRegistrationByID(ctx context.Context, requestID string) (*models.RegistrationRequest, error)
+	CountAcceptedRegistrationsForEvent(ctx context.Context, eventID string) (int64, error)
 	HasAcceptedRegistration(ctx context.Context, eventID, userID string) (bool, error)
 	HasPendingOrAcceptedRegistration(ctx context.Context, eventID, userID string) (bool, error)
 	MarkRegistrationAccepted(ctx context.Context, requestID string) error

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -98,6 +98,43 @@ func (h *EventHandler) GetEventByID(c *gin.Context) {
 	c.JSON(http.StatusOK, event)
 }
 
+func (h *EventHandler) GetEventAttendanceSummary(c *gin.Context) {
+	eventID := strings.TrimSpace(c.Param("id"))
+	if eventID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "event id is required",
+		})
+		return
+	}
+
+	_, err := h.stores.Mongo.GetEventByID(c.Request.Context(), eventID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "event not found",
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch event",
+		})
+		return
+	}
+
+	attendeeCount, err := h.stores.Mongo.CountAcceptedRegistrationsForEvent(c.Request.Context(), eventID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch attendance summary",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"event_id":        eventID,
+		"attendee_count": attendeeCount,
+	})
+}
+
 // creates a new event
 func (h *EventHandler) CreateEvent(c *gin.Context) {
 	var event models.Event
@@ -191,9 +228,11 @@ func (h *EventHandler) syncMaxAttendeesHeadcount(ctx context.Context, id string,
 
 	switch {
 	case newMaxInt == -1:
+		// Unlimited events are not headcount-tracked in Redis.
 		return h.stores.Redis.DeleteEventHeadcount(ctx, id)
 
 	case existingEvent.MaxAttendees == -1:
+		// Moving from unlimited to limited starts Redis tracking at the new max.
 		return h.stores.Redis.SetEventHeadcount(ctx, id, newMaxInt)
 
 	default:
@@ -205,6 +244,7 @@ func (h *EventHandler) syncMaxAttendeesHeadcount(ctx context.Context, id string,
 		seatsTaken := existingEvent.MaxAttendees - currentRemaining
 		newRemaining := newMaxInt - seatsTaken
 		if newRemaining < 0 {
+			// Event already exceeds the new cap; remaining seats cannot be negative.
 			newRemaining = 0
 		}
 
@@ -404,14 +444,32 @@ func (h *EventHandler) RegisterForEvent(producer *registration.Producer) gin.Han
 			return
 		}
 
-		if err := producer.PublishRegistration(c.Request.Context(), created.RequestID, eventID, payload.Registrant.UserID); err != nil {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"error": "failed to queue registration for processing",
+		seatTaken, err := h.stores.Redis.TryTakeEventSeat(c.Request.Context(), eventID)
+		if err != nil {
+			_ = db.MarkRegistrationRejected(created.RequestID, models.ReasonInternalError)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to reserve event seat",
+			})
+			return
+		}
+		if !seatTaken {
+			_ = db.MarkRegistrationRejected(created.RequestID, models.ReasonCapacityFull)
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "event is full",
 			})
 			return
 		}
 
-		c.JSON(http.StatusAccepted, gin.H{
+		if err := db.MarkRegistrationAccepted(created.RequestID); err != nil {
+			_ = h.stores.Redis.ReleaseEventSeat(c.Request.Context(), eventID)
+			_ = db.MarkRegistrationRejected(created.RequestID, models.ReasonInternalError)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to send registration request",
+			})
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{
 			"message":    "registration request sent",
 			"event_id":   eventID,
 			"request_id": created.RequestID,

--- a/pkg/handlers/event_test.go
+++ b/pkg/handlers/event_test.go
@@ -2,12 +2,117 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
 	"github.com/SCE-Development/SCEvents/pkg/mocks"
 	"github.com/SCE-Development/SCEvents/pkg/models"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/mongo"
 )
+
+func newAttendanceSummaryTestRouter(mongoStore db.MongoStore) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewEventHandler(&db.Stores{Mongo: mongoStore})
+	router.Use(func(c *gin.Context) {
+		c.Set("userID", "user-1")
+		c.Set("userRole", models.RoleMember)
+		c.Next()
+	})
+	router.GET("/events/:id/attendance", handler.GetEventAttendanceSummary)
+	return router
+}
+
+func TestGetEventAttendanceSummary(t *testing.T) {
+	t.Run("returns attendee count", func(t *testing.T) {
+		mongoStore := &mocks.MockMongoStore{
+			Event:         &models.Event{ID: "event-1", Admins: []string{"user-1"}},
+			AttendeeCount: 2,
+		}
+		router := newAttendanceSummaryTestRouter(mongoStore)
+
+		req := httptest.NewRequest(http.MethodGet, "/events/event-1/attendance", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		var body map[string]interface{}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("expected valid JSON, got %v", err)
+		}
+		if body["event_id"] != "event-1" {
+			t.Fatalf("expected event_id event-1, got %v", body["event_id"])
+		}
+		if body["attendee_count"] != float64(2) {
+			t.Fatalf("expected attendee_count 2, got %v", body["attendee_count"])
+		}
+		if !mongoStore.CountCalled {
+			t.Fatal("expected attendee count query to be called")
+		}
+	})
+
+	t.Run("returns not found for missing event", func(t *testing.T) {
+		mongoStore := &mocks.MockMongoStore{EventErr: mongo.ErrNoDocuments}
+		router := newAttendanceSummaryTestRouter(mongoStore)
+
+		req := httptest.NewRequest(http.MethodGet, "/events/event-1/attendance", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", w.Code)
+		}
+		if mongoStore.CountCalled {
+			t.Fatal("expected attendee count query not to be called")
+		}
+	})
+
+	t.Run("returns server error when count fails", func(t *testing.T) {
+		mongoStore := &mocks.MockMongoStore{
+			Event:            &models.Event{ID: "event-1", Admins: []string{"user-1"}},
+			AttendeeCountErr: errors.New("count failed"),
+		}
+		router := newAttendanceSummaryTestRouter(mongoStore)
+
+		req := httptest.NewRequest(http.MethodGet, "/events/event-1/attendance", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+		if !mongoStore.CountCalled {
+			t.Fatal("expected attendee count query to be called")
+		}
+	})
+
+	t.Run("returns attendee count for non-admin", func(t *testing.T) {
+		mongoStore := &mocks.MockMongoStore{
+			Event:         &models.Event{ID: "event-1", Admins: []string{"user-2"}},
+			AttendeeCount: 1,
+		}
+		router := newAttendanceSummaryTestRouter(mongoStore)
+
+		req := httptest.NewRequest(http.MethodGet, "/events/event-1/attendance", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+		if !mongoStore.CountCalled {
+			t.Fatal("expected attendee count query to be called")
+		}
+	})
+}
 
 func newTestHandler(redis db.RedisStore) *EventHandler {
 	return &EventHandler{

--- a/pkg/mocks/mongo.go
+++ b/pkg/mocks/mongo.go
@@ -11,6 +11,9 @@ type MockMongoStore struct {
 	RegistrationErr error
 	Event           *models.Event
 	EventErr        error
+	AttendeeCount   int64
+	AttendeeCountErr error
+	CountCalled     bool
 	HasAccepted     bool
 	HasAcceptedErr  error
 	MarkAcceptedErr error
@@ -38,6 +41,10 @@ func (m *MockMongoStore) CreatePendingRegistration(_ context.Context, r models.R
 }
 func (m *MockMongoStore) GetRegistrationByID(_ context.Context, _ string) (*models.RegistrationRequest, error) {
 	return m.Registration, m.RegistrationErr
+}
+func (m *MockMongoStore) CountAcceptedRegistrationsForEvent(_ context.Context, _ string) (int64, error) {
+	m.CountCalled = true
+	return m.AttendeeCount, m.AttendeeCountErr
 }
 func (m *MockMongoStore) HasAcceptedRegistration(_ context.Context, _, _ string) (bool, error) {
 	return m.HasAccepted, m.HasAcceptedErr


### PR DESCRIPTION
# For PR #95

## Problem

SCEvents did not expose accepted attendee counts for event cards. Unlimited events were also treated as full because Redis stored no-limit capacity as `-1`, but seat reservation treated values `<= 0` as unavailable.

## Solution

- Added accepted-registration counting from Mongo.
- Added `GET /events/:id/attendance`.
- Restricted attendance count access to event admins/site admins.
- Initialized Mongo in `Stores`.
- Completed registrations synchronously when capacity allows.
- Updated Redis seat logic so `-1` means unlimited.
- Added tests for attendee counting and unlimited capacity behavior.

## Files Changed

- `SCEvents/cmd/server/main.go`
- `SCEvents/pkg/db/registration.go`
- `SCEvents/pkg/db/stores.go`
- `SCEvents/pkg/db/redis.go`
- `SCEvents/pkg/db/redis_test.go`
- `SCEvents/pkg/db/registration_test.go`
- `SCEvents/pkg/handlers/event.go`
- `SCEvents/pkg/handlers/event_test.go`
- `SCEvents/pkg/registration/consumer_test.go`

## Separate Problems Solved

### Unlimited Events Were Treated As Full

`max_attendees = -1` was stored in Redis, but seat reservation treated `-1` as full.

Solution: treat negative headcount as unlimited and do not decrement.

### Store Wiring Was Incomplete

The new attendance handler used `stores.Mongo`, but server startup only initialized Redis in `Stores`.

Solution: initialize Mongo in `Stores`.

### Pending Registration Did Not Affect Count

The attendee count only counts accepted registrations.

Solution: complete registration synchronously when capacity allows.

## Possible Follow-Up Issues

- Add public attendee names/lists with consent UX.
- Refactor DB access to consistently use injected stores instead of mixing global DB functions and `stores.Mongo`.