### PR TITLE
Persist data in prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: mongo
     restart: unless-stopped
     volumes:
-      - scevents_mongodb_data:/data/db
+      - ./data/mongo:/data/db
     healthcheck:
       test: ["CMD", "mongo", "--quiet", "--eval", "db.adminCommand('ping')"]
       interval: 5s
@@ -16,7 +16,7 @@ services:
     restart: unless-stopped
     command: ["redis-server", "--appendonly", "yes"]
     volumes:
-      - scevents_redis_data:/data
+      - ./data/redis:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -89,7 +89,3 @@ networks:
   default:
     external: true
     name: sce
-
-volumes:
-  scevents_mongodb_data:
-  scevents_redis_data:


### PR DESCRIPTION
our data was being handled by Docker which is fine but i think we should prefer to mount data to volumes on the server? 

- we can switch to some other solution later if needed
- i don't think this will overload our server, doubt events will be a lot of data (in the short term at least)