### PR TITLE
Add registration_status to events response and related tests

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,6 +53,7 @@ func main() {
 	mongoStore := db.NewMongoStore(
 		db.GetEventsCollection(),
 		db.GetRegistrationsCollection(),
+		db.GetWaitlistCollection(),
 	)
 
 	stores := &db.Stores{
@@ -96,10 +97,12 @@ func main() {
 	})
 
 	events := r.Group("/events")
+	// public event reads can use optional auth so authenticated callers receive personalized event metadata
+	events.Use(middleware.OptionalAuth(cfg.ClientAPIURL))
 	{
+		events.GET("/registrations/:request_id", eventHandler.GetRegistrationStatus)
 		events.GET("/", eventHandler.GetEvents)
 		events.GET("/:id", eventHandler.GetEventByID)
-		events.GET("/registrations/:request_id", eventHandler.GetRegistrationStatus)
 
 		protected := events.Group("/")
 		protected.Use(middleware.RequireAuth(middleware.MembershipStateNonMember, cfg.ClientAPIURL))

--- a/pkg/db/event_test.go
+++ b/pkg/db/event_test.go
@@ -14,7 +14,7 @@ func TestCreateEvent(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("success", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		mt.AddMockResponses(mtest.CreateSuccessResponse())
 		event := models.Event{
 			ID:           "event-1",
@@ -34,7 +34,7 @@ func TestCreateEvent(t *testing.T) {
 	})
 
 	mt.Run("generates ID when empty", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		mt.AddMockResponses(mtest.CreateSuccessResponse())
 		event := models.Event{
 			Name:     "Test Event",
@@ -52,7 +52,7 @@ func TestCreateEvent(t *testing.T) {
 	})
 
 	mt.Run("duplicate key error", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		mt.AddMockResponses(mtest.CreateWriteErrorsResponse(mtest.WriteError{
 			Index:   0,
 			Code:    11000,
@@ -75,7 +75,7 @@ func TestGetEventByID(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("found", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
 			{Key: "_id", Value: "event-1"},
@@ -98,7 +98,7 @@ func TestGetEventByID(t *testing.T) {
 	})
 
 	mt.Run("not found", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
 		_, err := store.GetEventByID(context.Background(), "nonexistent")
@@ -112,7 +112,7 @@ func TestDeleteEventByID(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("success", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		mt.AddMockResponses(bson.D{{Key: "ok", Value: 1}, {Key: "n", Value: int32(1)}})
 		if err := store.DeleteEventByID(context.Background(), "event-1"); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -120,7 +120,7 @@ func TestDeleteEventByID(t *testing.T) {
 	})
 
 	mt.Run("not found", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		mt.AddMockResponses(bson.D{{Key: "ok", Value: 1}, {Key: "n", Value: int32(0)}})
 		err := store.DeleteEventByID(context.Background(), "nonexistent")
 		if err != mongo.ErrNoDocuments {
@@ -133,7 +133,7 @@ func TestUpdateEventByID(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("success", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		mt.AddMockResponses(bson.D{
 			{Key: "ok", Value: 1},
 			{Key: "n", Value: int32(1)},
@@ -148,7 +148,7 @@ func TestUpdateEventByID(t *testing.T) {
 	})
 
 	mt.Run("not found", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		mt.AddMockResponses(bson.D{
 			{Key: "ok", Value: 1},
 			{Key: "n", Value: int32(0)},
@@ -167,7 +167,7 @@ func TestGetEvents(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("returns matching events", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch,
 			bson.D{
@@ -198,7 +198,7 @@ func TestGetEvents(t *testing.T) {
 	})
 
 	mt.Run("empty result", func(mt *mtest.T) {
-		store := NewMongoStore(mt.Coll, nil)
+		store := NewMongoStore(mt.Coll, nil, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
 		events, err := store.GetEvents(context.Background(), "2026-05-01", "2026-05-31")

--- a/pkg/db/registration.go
+++ b/pkg/db/registration.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/SCE-Development/SCEvents/pkg/models"
@@ -20,12 +21,21 @@ func InitRegistrationIndexes() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{
-			{Key: "event_id", Value: 1},
-			{Key: "status", Value: 1},
+	_, err := coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "event_id", Value: 1},
+				{Key: "status", Value: 1},
+			},
+			Options: options.Index().SetName("event_id_status"),
 		},
-		Options: options.Index().SetName("event_id_status"),
+		{
+			Keys: bson.D{
+				{Key: "registrant.user_id", Value: 1},
+				{Key: "event_id", Value: 1},
+			},
+			Options: options.Index().SetName("registrant_user_event"),
+		},
 	})
 	return err
 }
@@ -319,4 +329,56 @@ func (s *mongoStore) MarkRegistrationRejected(ctx context.Context, requestID str
 		return mongo.ErrNoDocuments
 	}
 	return nil
+}
+
+// Higher values win when multiple registration records exist for the same user-event pair
+func registrationStatusPriority(status models.Status) int {
+	switch status {
+	case models.StatusAccepted:
+		return 3
+	case models.StatusPending:
+		return 2
+	case models.StatusRejected:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// GetRegistrationStatusesForUser batch-loads the caller's strongest registration state for each event
+func (s *mongoStore) GetRegistrationStatusesForUser(ctx context.Context, userID string, eventIDs []string) (map[string]models.Status, error) {
+	result := make(map[string]models.Status)
+
+	if strings.TrimSpace(userID) == "" || len(eventIDs) == 0 {
+		return result, nil
+	}
+
+	filter := bson.M{
+		"registrant.user_id": userID,
+		"event_id": bson.M{
+			"$in": eventIDs,
+		},
+	}
+
+	cursor, err := s.registrations.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = cursor.Close(ctx)
+	}()
+
+	var requests []models.RegistrationRequest
+	if err := cursor.All(ctx, &requests); err != nil {
+		return nil, err
+	}
+
+	for _, req := range requests {
+		current, exists := result[req.EventID]
+		if !exists || registrationStatusPriority(req.Status) > registrationStatusPriority(current) {
+			result[req.EventID] = req.Status
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/db/registration_test.go
+++ b/pkg/db/registration_test.go
@@ -14,7 +14,7 @@ func TestCreatePendingRegistration(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("success", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		mt.AddMockResponses(mtest.CreateSuccessResponse())
 		req := models.RegistrationRequest{
 			RequestID: "req-1",
@@ -45,7 +45,7 @@ func TestGetRegistrationByID(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("found", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
 			{Key: "_id", Value: "req-1"},
@@ -70,7 +70,7 @@ func TestGetRegistrationByID(t *testing.T) {
 	})
 
 	mt.Run("not found", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
 		_, err := store.GetRegistrationByID(context.Background(), "nonexistent")
@@ -84,7 +84,7 @@ func TestCountAcceptedRegistrationsForEvent(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("returns count", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
 			{Key: "n", Value: int32(2)},
@@ -99,7 +99,7 @@ func TestCountAcceptedRegistrationsForEvent(t *testing.T) {
 	})
 
 	mt.Run("returns zero", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
 			{Key: "n", Value: int32(0)},
@@ -118,7 +118,7 @@ func TestHasAcceptedRegistration(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("exists", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
 			{Key: "_id", Value: "req-1"},
@@ -135,7 +135,7 @@ func TestHasAcceptedRegistration(t *testing.T) {
 	})
 
 	mt.Run("does not exist", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
 		exists, err := store.HasAcceptedRegistration(context.Background(), "event-1", "user-1")
@@ -152,7 +152,7 @@ func TestHasPendingOrAcceptedRegistration(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("exists", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
 			{Key: "_id", Value: "req-1"},
@@ -169,7 +169,7 @@ func TestHasPendingOrAcceptedRegistration(t *testing.T) {
 	})
 
 	mt.Run("does not exist", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch))
 		exists, err := store.HasPendingOrAcceptedRegistration(context.Background(), "event-1", "user-1")
@@ -186,7 +186,7 @@ func TestMarkRegistrationAccepted(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("success", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		mt.AddMockResponses(bson.D{
 			{Key: "ok", Value: 1},
 			{Key: "n", Value: int32(1)},
@@ -198,7 +198,7 @@ func TestMarkRegistrationAccepted(t *testing.T) {
 	})
 
 	mt.Run("not found", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		mt.AddMockResponses(bson.D{
 			{Key: "ok", Value: 1},
 			{Key: "n", Value: int32(0)},
@@ -215,7 +215,7 @@ func TestMarkRegistrationRejected(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	mt.Run("success", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		mt.AddMockResponses(bson.D{
 			{Key: "ok", Value: 1},
 			{Key: "n", Value: int32(1)},
@@ -227,7 +227,7 @@ func TestMarkRegistrationRejected(t *testing.T) {
 	})
 
 	mt.Run("not found", func(mt *mtest.T) {
-		store := NewMongoStore(nil, mt.Coll)
+		store := NewMongoStore(nil, mt.Coll, nil)
 		mt.AddMockResponses(bson.D{
 			{Key: "ok", Value: 1},
 			{Key: "n", Value: int32(0)},
@@ -236,6 +236,116 @@ func TestMarkRegistrationRejected(t *testing.T) {
 		err := store.MarkRegistrationRejected(context.Background(), "nonexistent", models.ReasonCapacityFull)
 		if err != mongo.ErrNoDocuments {
 			t.Fatalf("expected ErrNoDocuments, got %v", err)
+		}
+	})
+}
+
+func TestGetRegistrationStatusesForUser(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+
+	mt.Run("empty userID returns empty map", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll, nil)
+
+		result, err := store.GetRegistrationStatusesForUser(context.Background(), "", []string{"event-1"})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(result) != 0 {
+			t.Fatalf("expected empty map, got %v", result)
+		}
+	})
+
+	mt.Run("empty eventIDs returns empty map", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll, nil)
+
+		result, err := store.GetRegistrationStatusesForUser(context.Background(), "user-1", nil)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(result) != 0 {
+			t.Fatalf("expected empty map, got %v", result)
+		}
+	})
+
+	mt.Run("returns statuses for multiple events", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll, nil)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch,
+			bson.D{
+				{Key: "_id", Value: "req-1"},
+				{Key: "event_id", Value: "event-1"},
+				{Key: "status", Value: "accepted"},
+				{Key: "registrant", Value: bson.D{{Key: "user_id", Value: "user-1"}}},
+			},
+			bson.D{
+				{Key: "_id", Value: "req-2"},
+				{Key: "event_id", Value: "event-2"},
+				{Key: "status", Value: "pending"},
+				{Key: "registrant", Value: bson.D{{Key: "user_id", Value: "user-1"}}},
+			},
+			bson.D{
+				{Key: "_id", Value: "req-3"},
+				{Key: "event_id", Value: "event-3"},
+				{Key: "status", Value: "rejected"},
+				{Key: "registrant", Value: bson.D{{Key: "user_id", Value: "user-1"}}},
+			},
+		))
+
+		result, err := store.GetRegistrationStatusesForUser(context.Background(), "user-1", []string{"event-1", "event-2", "event-3"})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		expected := map[string]models.Status{
+			"event-1": models.StatusAccepted,
+			"event-2": models.StatusPending,
+			"event-3": models.StatusRejected,
+		}
+
+		if len(result) != len(expected) {
+			t.Fatalf("expected %d statuses, got %d", len(expected), len(result))
+		}
+
+		for eventID, status := range expected {
+			if result[eventID] != status {
+				t.Fatalf("expected %s => %s, got %s", eventID, status, result[eventID])
+			}
+		}
+	})
+
+	mt.Run("strongest status wins for same event", func(mt *mtest.T) {
+		store := NewMongoStore(nil, mt.Coll, nil)
+		ns := mt.Coll.Database().Name() + "." + mt.Coll.Name()
+
+		mt.AddMockResponses(mtest.CreateCursorResponse(0, ns, mtest.FirstBatch,
+			bson.D{
+				{Key: "_id", Value: "req-1"},
+				{Key: "event_id", Value: "event-1"},
+				{Key: "status", Value: "rejected"},
+				{Key: "registrant", Value: bson.D{{Key: "user_id", Value: "user-1"}}},
+			},
+			bson.D{
+				{Key: "_id", Value: "req-2"},
+				{Key: "event_id", Value: "event-1"},
+				{Key: "status", Value: "pending"},
+				{Key: "registrant", Value: bson.D{{Key: "user_id", Value: "user-1"}}},
+			},
+			bson.D{
+				{Key: "_id", Value: "req-3"},
+				{Key: "event_id", Value: "event-1"},
+				{Key: "status", Value: "accepted"},
+				{Key: "registrant", Value: bson.D{{Key: "user_id", Value: "user-1"}}},
+			},
+		))
+
+		result, err := store.GetRegistrationStatusesForUser(context.Background(), "user-1", []string{"event-1"})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if result["event-1"] != models.StatusAccepted {
+			t.Fatalf("expected event-1 => accepted, got %s", result["event-1"])
 		}
 	})
 }

--- a/pkg/db/stores.go
+++ b/pkg/db/stores.go
@@ -35,6 +35,8 @@ type MongoStore interface {
 	HasPendingOrAcceptedRegistration(ctx context.Context, eventID, userID string) (bool, error)
 	MarkRegistrationAccepted(ctx context.Context, requestID string) error
 	MarkRegistrationRejected(ctx context.Context, requestID string, reason models.DecisionReason) error
+	GetRegistrationStatusesForUser(ctx context.Context, userID string, eventIDs []string) (map[string]models.Status, error)
+	GetWaitlistedEventIDsForUser(ctx context.Context, userID string, eventIDs []string) (map[string]bool, error)
 }
 
 type Stores struct {
@@ -46,8 +48,14 @@ type Stores struct {
 type mongoStore struct {
 	events        *mongo.Collection
 	registrations *mongo.Collection
+	waitlists     *mongo.Collection
 }
 
-func NewMongoStore(events, registrations *mongo.Collection) MongoStore {
-	return &mongoStore{events: events, registrations: registrations}
+// Batch user-event lookups used to enrich event responses with per-user registration state
+func NewMongoStore(events, registrations, waitlists *mongo.Collection) MongoStore {
+	return &mongoStore{
+		events:        events,
+		registrations: registrations,
+		waitlists:     waitlists,
+	}
 }

--- a/pkg/db/waitlist.go
+++ b/pkg/db/waitlist.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/SCE-Development/SCEvents/pkg/models"
@@ -82,4 +83,39 @@ func CountWaitlistEntries(eventID string) (int64, error) {
 	}
 
 	return coll.CountDocuments(ctx, filter)
+}
+
+// GetWaitlistedEventIDsForUser returns a set of event IDs the user is currently waitlisted for
+func (s *mongoStore) GetWaitlistedEventIDsForUser(ctx context.Context, userID string, eventIDs []string) (map[string]bool, error) {
+	result := make(map[string]bool)
+
+	if strings.TrimSpace(userID) == "" || len(eventIDs) == 0 {
+		return result, nil
+	}
+
+	filter := bson.M{
+		"user_id": userID,
+		"event_id": bson.M{
+			"$in": eventIDs,
+		},
+	}
+
+	cursor, err := s.waitlists.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = cursor.Close(ctx)
+	}()
+
+	var entries []models.WaitlistEntry
+	if err := cursor.All(ctx, &entries); err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		result[entry.EventID] = true
+	}
+
+	return result, nil
 }

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -27,6 +27,37 @@ func NewEventHandler(stores *db.Stores) *EventHandler {
 
 const dateLayout = "2006-01-02"
 
+// EventRegistrationStatus is the UI-facing per-user status attached to event responses
+type EventRegistrationStatus string
+
+const (
+	EventRegistrationStatusNone       EventRegistrationStatus = "none"
+	EventRegistrationStatusPending    EventRegistrationStatus = "pending"
+	EventRegistrationStatusRegistered EventRegistrationStatus = "registered"
+	EventRegistrationStatusWaitlisted EventRegistrationStatus = "waitlisted"
+	EventRegistrationStatusRejected   EventRegistrationStatus = "rejected"
+)
+
+type EventResponse struct {
+	ID                 string                    `json:"id"`
+	Name               string                    `json:"name"`
+	Date               string                    `json:"date"`
+	EndDate            string                    `json:"end_date,omitempty"`
+	Time               string                    `json:"time"`
+	Location           string                    `json:"location"`
+	Description        string                    `json:"description"`
+	Admins             []string                  `json:"admins"`
+	RegistrationForm   []models.FormQuestion     `json:"registration_form"`
+	MaxAttendees       int                       `json:"max_attendees"`
+	CreatedAt          string                    `json:"created_at"`
+	Status             string                    `json:"status"`
+	Visibility         string                    `json:"visibility"`
+	MinimumVisibleRole string                    `json:"minimum_visible_role,omitempty"`
+	WaitlistEnabled    bool                      `json:"waitlist_enabled"`
+	WaitlistSize       int                       `json:"waitlist_size,omitempty"`
+	RegistrationStatus *EventRegistrationStatus  `json:"registration_status,omitempty"`
+}
+
 func writeEventEditForbidden(c *gin.Context, ev *models.Event) {
 	if len(ev.Admins) == 0 {
 		c.JSON(http.StatusForbidden, gin.H{
@@ -73,21 +104,47 @@ func (h *EventHandler) GetEvents(c *gin.Context) {
 		return
 	}
 
-	events, err := db.GetEvents(startDate, endDate)
+	events, err := h.stores.Mongo.GetEvents(c.Request.Context(), startDate, endDate)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "failed to fetch events",
 		})
 		return
 	}
-	c.JSON(http.StatusOK, events)
+
+	userID := strings.TrimSpace(c.GetString("userID"))
+	if userID == "" {
+		c.JSON(http.StatusOK, buildEventResponses(events, "", nil, nil))
+		return
+	}
+
+	eventIDs := collectEventIDs(events)
+
+	registrationStatuses, err := h.stores.Mongo.GetRegistrationStatusesForUser(c.Request.Context(), userID, eventIDs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch registration statuses",
+		})
+		return
+	}
+
+	waitlistedEventIDs, err := h.stores.Mongo.GetWaitlistedEventIDsForUser(c.Request.Context(), userID, eventIDs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch waitlist statuses",
+		})
+		return
+	}
+
+	responses := buildEventResponses(events, userID, registrationStatuses, waitlistedEventIDs)
+	c.JSON(http.StatusOK, responses)
 }
 
 // returns a single event by ID
 func (h *EventHandler) GetEventByID(c *gin.Context) {
 	id := c.Param("id")
 
-	event, err := db.GetEventByID(id)
+	event, err := h.stores.Mongo.GetEventByID(c.Request.Context(), id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": "event not found",
@@ -95,7 +152,34 @@ func (h *EventHandler) GetEventByID(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, event)
+	userID := strings.TrimSpace(c.GetString("userID"))
+	if userID == "" {
+		c.JSON(http.StatusOK, buildEventResponse(*event, nil))
+		return
+	}
+
+	eventIDs := []string{event.ID}
+
+	registrationStatuses, err := h.stores.Mongo.GetRegistrationStatusesForUser(c.Request.Context(), userID, eventIDs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch registration status",
+		})
+		return
+	}
+
+	waitlistedEventIDs, err := h.stores.Mongo.GetWaitlistedEventIDsForUser(c.Request.Context(), userID, eventIDs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch waitlist status",
+		})
+		return
+	}
+
+	status := resolveEventRegistrationStatus(event.ID, registrationStatuses, waitlistedEventIDs)
+	statusCopy := status
+
+	c.JSON(http.StatusOK, buildEventResponse(*event, &statusCopy))
 }
 
 func (h *EventHandler) GetEventAttendanceSummary(c *gin.Context) {
@@ -631,4 +715,84 @@ func (h *EventHandler) GetRegistrationStatus(c *gin.Context) {
 		"updated_at":      req.UpdatedAt,
 		"processed_at":    req.ProcessedAt,
 	})
+}
+
+// buildEventResponses attaches registration_status only when user context is available
+func buildEventResponse(event models.Event, registrationStatus *EventRegistrationStatus) EventResponse {
+	return EventResponse{
+		ID:                 event.ID,
+		Name:               event.Name,
+		Date:               event.Date,
+		EndDate:            event.EndDate,
+		Time:               event.Time,
+		Location:           event.Location,
+		Description:        event.Description,
+		Admins:             event.Admins,
+		RegistrationForm:   event.RegistrationForm,
+		MaxAttendees:       event.MaxAttendees,
+		CreatedAt:          event.CreatedAt,
+		Status:             event.Status,
+		Visibility:         event.Visibility,
+		MinimumVisibleRole: event.MinimumVisibleRole,
+		WaitlistEnabled:    event.WaitlistEnabled,
+		WaitlistSize:       event.WaitlistSize,
+		RegistrationStatus: registrationStatus,
+	}
+}
+
+// resolveEventRegistrationStatus maps persisted registration/waitlist records into one UI-facing status
+func resolveEventRegistrationStatus(
+	eventID string,
+	registrationStatuses map[string]models.Status,
+	waitlistedEventIDs map[string]bool,
+) EventRegistrationStatus {
+	if status, ok := registrationStatuses[eventID]; ok {
+		switch status {
+		case models.StatusAccepted:
+			return EventRegistrationStatusRegistered
+		case models.StatusPending:
+			return EventRegistrationStatusPending
+		case models.StatusRejected:
+			if waitlistedEventIDs[eventID] {
+				return EventRegistrationStatusWaitlisted
+			}
+			return EventRegistrationStatusRejected
+		}
+	}
+
+	if waitlistedEventIDs[eventID] {
+		return EventRegistrationStatusWaitlisted
+	}
+
+	return EventRegistrationStatusNone
+}
+
+func collectEventIDs(events []models.Event) []string {
+	ids := make([]string, 0, len(events))
+	for _, event := range events {
+		ids = append(ids, event.ID)
+	}
+	return ids
+}
+
+func buildEventResponses(
+	events []models.Event,
+	userID string,
+	registrationStatuses map[string]models.Status,
+	waitlistedEventIDs map[string]bool,
+) []EventResponse {
+	responses := make([]EventResponse, 0, len(events))
+
+	for _, event := range events {
+		if strings.TrimSpace(userID) == "" {
+			responses = append(responses, buildEventResponse(event, nil))
+			continue
+		}
+
+		status := resolveEventRegistrationStatus(event.ID, registrationStatuses, waitlistedEventIDs)
+		statusCopy := status
+		responses = append(responses, buildEventResponse(event, &statusCopy))
+	}
+
+	return responses
 }

--- a/pkg/handlers/event_test.go
+++ b/pkg/handlers/event_test.go
@@ -189,3 +189,383 @@ func TestSyncMaxAttendeesHeadcount_FiniteToFinite(t *testing.T) {
 		t.Fatalf("expected remaining capacity 9, got %d", redis.SetCapacity)
 	}
 }
+
+func newEventReadTestRouter(mongoStore db.MongoStore, userID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewEventHandler(&db.Stores{Mongo: mongoStore})
+
+	router.Use(func(c *gin.Context) {
+		if userID != "" {
+			c.Set("userID", userID)
+		}
+		c.Next()
+	})
+
+	router.GET("/events", handler.GetEvents)
+	router.GET("/events/:id", handler.GetEventByID)
+
+	return router
+}
+
+func TestGetEvents_Unauthenticated_OmitsRegistrationStatus(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Events: []models.Event{
+			{ID: "event-1", Name: "Hack Night"},
+		},
+	}
+	router := newEventReadTestRouter(mongoStore, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var body []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if len(body) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(body))
+	}
+
+	if _, ok := body[0]["registration_status"]; ok {
+		t.Fatalf("expected registration_status to be omitted, got %v", body[0]["registration_status"])
+	}
+}
+
+func TestGetEvents_Authenticated_ReturnsRegistrationStatus(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Events: []models.Event{
+			{ID: "event-1", Name: "Hack Night"},
+			{ID: "event-2", Name: "Company Tour"},
+			{ID: "event-3", Name: "Workshop"},
+		},
+		RegistrationStatuses: map[string]models.Status{
+			"event-1": models.StatusAccepted,
+			"event-2": models.StatusPending,
+			"event-3": models.StatusRejected,
+		},
+		WaitlistedEventIDs: map[string]bool{},
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var body []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	got := map[string]string{}
+	for _, event := range body {
+		got[event["id"].(string)] = event["registration_status"].(string)
+	}
+
+	if got["event-1"] != "registered" {
+		t.Fatalf("expected event-1 registered, got %s", got["event-1"])
+	}
+	if got["event-2"] != "pending" {
+		t.Fatalf("expected event-2 pending, got %s", got["event-2"])
+	}
+	if got["event-3"] != "rejected" {
+		t.Fatalf("expected event-3 rejected, got %s", got["event-3"])
+	}
+}
+
+func TestGetEvents_Authenticated_WaitlistOverridesRejected(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Events: []models.Event{
+			{ID: "event-1", Name: "Hack Night"},
+		},
+		RegistrationStatuses: map[string]models.Status{
+			"event-1": models.StatusRejected,
+		},
+		WaitlistedEventIDs: map[string]bool{
+			"event-1": true,
+		},
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var body []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if body[0]["registration_status"] != "waitlisted" {
+		t.Fatalf("expected waitlisted, got %v", body[0]["registration_status"])
+	}
+}
+
+func TestGetEvents_Authenticated_WaitlistOnly(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Events: []models.Event{
+			{ID: "event-1", Name: "Hack Night"},
+		},
+		RegistrationStatuses: map[string]models.Status{},
+		WaitlistedEventIDs: map[string]bool{
+			"event-1": true,
+		},
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var body []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if body[0]["registration_status"] != "waitlisted" {
+		t.Fatalf("expected waitlisted, got %v", body[0]["registration_status"])
+	}
+}
+
+func TestGetEvents_Authenticated_NoStatus_ReturnsNone(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Events: []models.Event{
+			{ID: "event-1", Name: "Hack Night"},
+		},
+		RegistrationStatuses: map[string]models.Status{},
+		WaitlistedEventIDs:   map[string]bool{},
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var body []map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if body[0]["registration_status"] != "none" {
+		t.Fatalf("expected none, got %v", body[0]["registration_status"])
+	}
+}
+
+func TestGetEvents_Returns500_WhenRegistrationLookupFails(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Events:                  []models.Event{{ID: "event-1", Name: "Hack Night"}},
+		RegistrationStatusesErr: errors.New("boom"),
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestGetEvents_Returns500_WhenWaitlistLookupFails(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Events:              []models.Event{{ID: "event-1", Name: "Hack Night"}},
+		RegistrationStatuses: map[string]models.Status{},
+		WaitlistedEventIDsErr: errors.New("boom"),
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestGetEventByID_Unauthenticated_OmitsRegistrationStatus(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Event: &models.Event{ID: "event-1", Name: "Hack Night"},
+	}
+	router := newEventReadTestRouter(mongoStore, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/events/event-1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if _, ok := body["registration_status"]; ok {
+		t.Fatalf("expected registration_status to be omitted, got %v", body["registration_status"])
+	}
+}
+
+func TestGetEventByID_Authenticated_ReturnsRegistered(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Event: &models.Event{ID: "event-1", Name: "Hack Night"},
+		RegistrationStatuses: map[string]models.Status{
+			"event-1": models.StatusAccepted,
+		},
+		WaitlistedEventIDs: map[string]bool{},
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events/event-1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if body["registration_status"] != "registered" {
+		t.Fatalf("expected registered, got %v", body["registration_status"])
+	}
+}
+
+func TestGetEventByID_Authenticated_ReturnsWaitlisted(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		Event: &models.Event{ID: "event-1", Name: "Hack Night"},
+		RegistrationStatuses: map[string]models.Status{
+			"event-1": models.StatusRejected,
+		},
+		WaitlistedEventIDs: map[string]bool{
+			"event-1": true,
+		},
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events/event-1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if body["registration_status"] != "waitlisted" {
+		t.Fatalf("expected waitlisted, got %v", body["registration_status"])
+	}
+}
+
+func TestGetEventByID_NotFound(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{
+		EventErr: mongo.ErrNoDocuments,
+	}
+	router := newEventReadTestRouter(mongoStore, "user-1")
+
+	req := httptest.NewRequest(http.MethodGet, "/events/event-1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", w.Code)
+	}
+}
+
+func TestResolveEventRegistrationStatus(t *testing.T) {
+	tests := []struct {
+		name                 string
+		registrationStatuses map[string]models.Status
+		waitlistedEventIDs   map[string]bool
+		expected             EventRegistrationStatus
+	}{
+		{
+			name: "accepted -> registered",
+			registrationStatuses: map[string]models.Status{
+				"event-1": models.StatusAccepted,
+			},
+			waitlistedEventIDs: map[string]bool{},
+			expected:           EventRegistrationStatusRegistered,
+		},
+		{
+			name: "pending -> pending",
+			registrationStatuses: map[string]models.Status{
+				"event-1": models.StatusPending,
+			},
+			waitlistedEventIDs: map[string]bool{},
+			expected:           EventRegistrationStatusPending,
+		},
+		{
+			name: "rejected -> rejected",
+			registrationStatuses: map[string]models.Status{
+				"event-1": models.StatusRejected,
+			},
+			waitlistedEventIDs: map[string]bool{},
+			expected:           EventRegistrationStatusRejected,
+		},
+		{
+			name: "rejected + waitlisted -> waitlisted",
+			registrationStatuses: map[string]models.Status{
+				"event-1": models.StatusRejected,
+			},
+			waitlistedEventIDs: map[string]bool{
+				"event-1": true,
+			},
+			expected: EventRegistrationStatusWaitlisted,
+		},
+		{
+			name:                 "waitlist only -> waitlisted",
+			registrationStatuses: map[string]models.Status{},
+			waitlistedEventIDs: map[string]bool{
+				"event-1": true,
+			},
+			expected: EventRegistrationStatusWaitlisted,
+		},
+		{
+			name:                 "nothing -> none",
+			registrationStatuses: map[string]models.Status{},
+			waitlistedEventIDs:   map[string]bool{},
+			expected:             EventRegistrationStatusNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveEventRegistrationStatus("event-1", tt.registrationStatuses, tt.waitlistedEventIDs)
+			if result != tt.expected {
+				t.Fatalf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -2,8 +2,8 @@ package middleware
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -28,53 +28,84 @@ func RequireAuth(minimumState int, clientAPIURL string) gin.HandlerFunc {
 			return
 		}
 
-		req, _ := http.NewRequest("POST", clientAPIURL+"/api/Auth/verify", nil)
-		req.Header.Set("Authorization", authHeader)
-
-		client := &http.Client{}
-		resp, err := client.Do(req)
-		if err != nil || resp.StatusCode != http.StatusOK {
-			// if not success, the token was invalid or the API is down
+		userID, role, accessLevel, err := verifyAuthHeader(authHeader, clientAPIURL)
+		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Token verification failed"})
 			return
 		}
-		defer func() {
-			_ = resp.Body.Close()
-		}()
 
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to read token verification response"})
-			return
-		}
-
-		log.Printf("API Response: %s\n", string(bodyBytes))
-
-		// parse Clark's response (decoded JWT payload)
-		var user map[string]interface{}
-		if err := json.Unmarshal(bodyBytes, &user); err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse token verification response"})
-			return
-		}
-
-		// read accessLevel (float64 due to JSON unmarshaling)
-		accessLevel, ok := user["accessLevel"].(float64)
-		if !ok {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data from Clark API"})
-			return
-		}
-
-		if int(accessLevel) < minimumState {
+		if accessLevel < minimumState {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "Insufficient privileges"})
 			return
 		}
 
-		role := "User"
-		if int(accessLevel) >= MembershipStateOfficer {
-			role = "Admin"
+		c.Set("userID", userID)
+		c.Set("userRole", role)
+		c.Next()
+	}
+}
+
+func verifyAuthHeader(authHeader string, clientAPIURL string) (string, string, int, error) {
+	req, err := http.NewRequest("POST", clientAPIURL+"/api/Auth/verify", nil)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to create token verification request")
+	}
+	req.Header.Set("Authorization", authHeader)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return "", "", 0, fmt.Errorf("token verification failed")
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to read token verification response")
+	}
+
+	// parse Clark's response (decoded JWT payload)
+	var user map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &user); err != nil {
+		return "", "", 0, fmt.Errorf("failed to parse token verification response")
+	}
+
+	// read accessLevel (float64 due to JSON unmarshaling)
+	accessLevelFloat, ok := user["accessLevel"].(float64)
+	if !ok {
+		return "", "", 0, fmt.Errorf("invalid user data from Clark API")
+	}
+
+	accessLevel := int(accessLevelFloat)
+
+	role := "User"
+	if accessLevel >= MembershipStateOfficer {
+		role = "Admin"
+	}
+
+	userID, _ := user["_id"].(string)
+
+	return userID, role, accessLevel, nil
+}
+
+// OptionalAuth enriches the request with user context when a valid token is present,
+// but still allows anonymous access for public endpoints
+func OptionalAuth(clientAPIURL string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.Next()
+			return
 		}
 
-		userID, _ := user["_id"].(string)
+		userID, role, _, err := verifyAuthHeader(authHeader, clientAPIURL)
+		if err != nil {
+			// if not success, the token was invalid or the API is down
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Token verification failed"})
+			return
+		}
 
 		c.Set("userID", userID)
 		c.Set("userRole", role)

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -54,7 +54,7 @@ func TestRequireAuth(t *testing.T) {
 			mockAPIStatus: http.StatusOK,
 			mockAPIResponse: "invalid json", // It'll be sent as string without json encoding for testing fail in Unmarshal if not careful, wait I'll handle that in mock handler
 			minimumState: MembershipStateMember,
-			expectedStatus: http.StatusInternalServerError,
+			expectedStatus: http.StatusUnauthorized,
 		},
 		{
 			name:       "api returns insufficient access level",
@@ -139,5 +139,112 @@ func TestRequireAuth(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func setupOptionalAuthRouter(clientAPIURL string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(OptionalAuth(clientAPIURL))
+	r.GET("/test", func(c *gin.Context) {
+		userID, _ := c.Get("userID")
+		userRole, _ := c.Get("userRole")
+		c.JSON(http.StatusOK, gin.H{
+			"userID":   userID,
+			"userRole": userRole,
+		})
+	})
+	return r
+}
+
+func TestOptionalAuth_AllowsAnonymousRequest(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("verification API should not be called when auth header is missing")
+	}))
+	defer mockServer.Close()
+
+	router := setupOptionalAuthRouter(mockServer.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if _, ok := response["userID"]; ok && response["userID"] != nil {
+		t.Fatalf("expected no userID, got %v", response["userID"])
+	}
+	if _, ok := response["userRole"]; ok && response["userRole"] != nil {
+		t.Fatalf("expected no userRole, got %v", response["userRole"])
+	}
+}
+
+func TestOptionalAuth_SetsContextForValidToken(t *testing.T) {
+	authHeader := "Bearer valid-token"
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != authHeader {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"_id":         "user-123",
+			"accessLevel": float64(MembershipStateMember),
+		})
+	}))
+	defer mockServer.Close()
+
+	router := setupOptionalAuthRouter(mockServer.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", authHeader)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if response["userID"] != "user-123" {
+		t.Fatalf("expected userID user-123, got %s", response["userID"])
+	}
+	if response["userRole"] != "User" {
+		t.Fatalf("expected userRole User, got %s", response["userRole"])
+	}
+}
+
+func TestOptionalAuth_RejectsInvalidToken(t *testing.T) {
+	authHeader := "Bearer invalid-token"
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer mockServer.Close()
+
+	router := setupOptionalAuthRouter(mockServer.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", authHeader)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
 	}
 }

--- a/pkg/mocks/mongo.go
+++ b/pkg/mocks/mongo.go
@@ -7,22 +7,28 @@ import (
 )
 
 type MockMongoStore struct {
-	Registration    *models.RegistrationRequest
-	RegistrationErr error
-	Event           *models.Event
-	EventErr        error
-	AttendeeCount   int64
-	AttendeeCountErr error
-	CountCalled     bool
-	HasAccepted     bool
-	HasAcceptedErr  error
-	MarkAcceptedErr error
-	MarkRejectedErr error
-	RejectedReason  models.DecisionReason
+	Registration               *models.RegistrationRequest
+	RegistrationErr            error
+	Event                      *models.Event
+	EventErr                   error
+	AttendeeCount              int64
+	AttendeeCountErr           error
+	CountCalled                bool
+	HasAccepted                bool
+	HasAcceptedErr             error
+	MarkAcceptedErr            error
+	MarkRejectedErr            error
+	RejectedReason             models.DecisionReason
+	RegistrationStatuses       map[string]models.Status
+	RegistrationStatusesErr    error
+	WaitlistedEventIDs         map[string]bool
+	WaitlistedEventIDsErr      error
+	Events                     []models.Event
+	EventsErr                  error
 }
 
 func (m *MockMongoStore) GetEvents(_ context.Context, _, _ string) ([]models.Event, error) {
-	return nil, nil
+	return m.Events, m.EventsErr
 }
 func (m *MockMongoStore) GetEventByID(_ context.Context, _ string) (*models.Event, error) {
 	return m.Event, m.EventErr
@@ -58,4 +64,11 @@ func (m *MockMongoStore) MarkRegistrationAccepted(_ context.Context, _ string) e
 func (m *MockMongoStore) MarkRegistrationRejected(_ context.Context, _ string, reason models.DecisionReason) error {
 	m.RejectedReason = reason
 	return m.MarkRejectedErr
+}
+func (m *MockMongoStore) GetRegistrationStatusesForUser(_ context.Context, _ string, _ []string) (map[string]models.Status, error) {
+	return m.RegistrationStatuses, m.RegistrationStatusesErr
+}
+
+func (m *MockMongoStore) GetWaitlistedEventIDsForUser(_ context.Context, _ string, _ []string) (map[string]bool, error) {
+	return m.WaitlistedEventIDs, m.WaitlistedEventIDsErr
 }

--- a/pkg/models/registration.go
+++ b/pkg/models/registration.go
@@ -5,6 +5,7 @@ import "time"
 type Status string
 type DecisionReason string
 
+// Status values describe the lifecycle of a registration request in persistence
 const (
 	StatusPending  Status = "pending"
 	StatusAccepted Status = "accepted"


### PR DESCRIPTION
Partially resolved [Render event cards differently based on users' registration status #2097](https://github.com/SCE-Development/Clark/issues/2097)

### Summary
Adds `registration_status` to event responses so the frontend can render user-specific event states.

### Changes
- Augmented `GET /events` and `GET /events/:id` to include `registration_status`
- Implemented batch lookup for user registration statuses across events
- Added waitlist integration (waitlist overrides rejected)
- Introduced `OptionalAuth` for public endpoints with user context
- Added comprehensive unit tests for:
  - registration status aggregation
  - handler responses
  - middleware behavior

## Validation
- `go test ./...` passes
- Verified via curl with valid JWT:
  - accepted → `registered`
  - no record → `none`
 
```bash
curl -H "Authorization: Bearer <WORKING_TOKEN>" \
http://localhost:8002/events/
```

For examples:

```json
[{"id":"","name":"Spring Social","date":"2026-04-20","time":"18:00","location":"Student Union","description":"Casual meetup","admins":["user123"],"registration_form":[],"max_attendees":50,"created_at":"","status":"draft","visibility":"public","waitlist_enabled":false,"registration_status":"none"}
```

```json
{"id":"test-event-1","name":"Mongo Store Wiring Test","date":"2026-04-30","time":"6:00 PM","location":"ENGR 289","description":"test event","admins":[],"registration_form":[{"id":"major","type":"textbox","question":"What is your major?","required":true}],"max_attendees":1,"created_at":"2026-04-25T00:00:00Z","status":"closed","visibility":"public","waitlist_enabled":false,"registration_status":"registered"}
```

- Confirmed correctness against MongoDB registration data

## Notes
- [Design Doc](https://docs.google.com/document/d/1wE4X-_0kccqDb6SvqMAUr_P2v80PHeJlSTlgf_-5Nsk/edit?usp=sharing)