### PR TITLE
Added multi admin event management

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,7 +107,6 @@ func main() {
 		protected := events.Group("/")
 		protected.Use(middleware.RequireAuth(middleware.MembershipStateNonMember, cfg.ClientAPIURL))
 		{
-			protected.POST("/", eventHandler.CreateEvent)
 			protected.GET("/:id/attendance", eventHandler.GetEventAttendanceSummary)
 			protected.GET("/:id/registrations", eventHandler.ListEventRegistrations)
 			protected.GET("/:id/registrations/:request_id", eventHandler.GetEventRegistrationByRequestID)
@@ -115,6 +114,12 @@ func main() {
 			protected.POST("/:id/waitlist", eventHandler.JoinEventWaitlist)
 			protected.DELETE("/:id", eventHandler.DeleteEventByID)
 			protected.PATCH("/:id", eventHandler.UpdateEventByID)
+		}
+
+		adminProtected := events.Group("/")
+		adminProtected.Use(middleware.RequireAuth(middleware.MembershipStateOfficer, cfg.ClientAPIURL))
+		{
+			adminProtected.POST("/", eventHandler.CreateEvent)
 		}
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -112,14 +112,14 @@ func main() {
 			protected.GET("/:id/registrations/:request_id", eventHandler.GetEventRegistrationByRequestID)
 			protected.POST("/:id/register", eventHandler.RegisterForEvent(producer))
 			protected.POST("/:id/waitlist", eventHandler.JoinEventWaitlist)
-			protected.DELETE("/:id", eventHandler.DeleteEventByID)
-			protected.PATCH("/:id", eventHandler.UpdateEventByID)
 		}
 
-		adminProtected := events.Group("/")
-		adminProtected.Use(middleware.RequireAuth(middleware.MembershipStateOfficer, cfg.ClientAPIURL))
+		officerProtected := events.Group("/")
+		officerProtected.Use(middleware.RequireAuth(middleware.MembershipStateOfficer, cfg.ClientAPIURL))
 		{
-			adminProtected.POST("/", eventHandler.CreateEvent)
+			officerProtected.POST("/", eventHandler.CreateEvent)
+			officerProtected.DELETE("/:id", eventHandler.DeleteEventByID)
+			officerProtected.PATCH("/:id", eventHandler.UpdateEventByID)
 		}
 	}
 

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -242,7 +242,8 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 		return
 	}
 
-	event.Admins = ensureAdminIncluded(event.Admins, creatorID)
+	event.Admins = sanitizeAdmins(event.Admins)
+	event.Admins = ensureCreatorIsEventAdmin(event.Admins, creatorID)
 
 	if err := event.Validate(); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -274,9 +275,9 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 	c.JSON(http.StatusCreated, createdEvent)
 }
 
-func ensureAdminIncluded(admins []string, userID string) []string {
-	seen := make(map[string]struct{}, len(admins)+1)
-	normalized := make([]string, 0, len(admins)+1)
+func sanitizeAdmins(admins []string) []string {
+	seen := make(map[string]struct{}, len(admins))
+	normalized := make([]string, 0, len(admins))
 
 	for _, admin := range admins {
 		admin = strings.TrimSpace(admin)
@@ -290,11 +291,16 @@ func ensureAdminIncluded(admins []string, userID string) []string {
 		normalized = append(normalized, admin)
 	}
 
-	if _, ok := seen[userID]; !ok {
-		normalized = append(normalized, userID)
-	}
-
 	return normalized
+}
+
+func ensureCreatorIsEventAdmin(admins []string, creatorID string) []string {
+	for _, admin := range admins {
+		if admin == creatorID {
+			return admins
+		}
+	}
+	return append(admins, creatorID)
 }
 
 // deletes an event by ID
@@ -435,7 +441,7 @@ func (h *EventHandler) UpdateEventByID(c *gin.Context) {
 	}
 
 	if _, ok := fields["admins"]; ok {
-		fields["admins"] = updatedEvent.Admins
+		fields["admins"] = sanitizeAdmins(updatedEvent.Admins)
 	}
 
 	err = db.UpdateEventByID(id, fields)

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -234,6 +234,16 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 
 	event.ApplyDefaults()
 
+	creatorID := strings.TrimSpace(c.GetString("userID"))
+	if creatorID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "creator user id is required",
+		})
+		return
+	}
+
+	event.Admins = ensureAdminIncluded(event.Admins, creatorID)
+
 	if err := event.Validate(); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": err.Error(),
@@ -241,7 +251,7 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 		return
 	}
 
-	createdEvent, err := db.CreateEvent(event)
+	createdEvent, err := h.stores.Mongo.CreateEvent(c.Request.Context(), event)
 	if err != nil {
 		log.Printf("CreateEvent error: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -262,6 +272,29 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, createdEvent)
+}
+
+func ensureAdminIncluded(admins []string, userID string) []string {
+	seen := make(map[string]struct{}, len(admins)+1)
+	normalized := make([]string, 0, len(admins)+1)
+
+	for _, admin := range admins {
+		admin = strings.TrimSpace(admin)
+		if admin == "" {
+			continue
+		}
+		if _, ok := seen[admin]; ok {
+			continue
+		}
+		seen[admin] = struct{}{}
+		normalized = append(normalized, admin)
+	}
+
+	if _, ok := seen[userID]; !ok {
+		normalized = append(normalized, userID)
+	}
+
+	return normalized
 }
 
 // deletes an event by ID
@@ -399,6 +432,10 @@ func (h *EventHandler) UpdateEventByID(c *gin.Context) {
 
 	if _, ok := fields["minimum_visible_role"]; ok {
 		fields["minimum_visible_role"] = updatedEvent.MinimumVisibleRole
+	}
+
+	if _, ok := fields["admins"]; ok {
+		fields["admins"] = updatedEvent.Admins
 	}
 
 	err = db.UpdateEventByID(id, fields)

--- a/pkg/handlers/event_test.go
+++ b/pkg/handlers/event_test.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/SCE-Development/SCEvents/pkg/db"
@@ -113,6 +115,127 @@ func TestGetEventAttendanceSummary(t *testing.T) {
 		}
 	})
 }
+
+func newCreateEventTestRouter(mongoStore db.MongoStore, redisStore db.RedisStore, userID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewEventHandler(&db.Stores{Mongo: mongoStore, Redis: redisStore})
+	router.Use(func(c *gin.Context) {
+		c.Set("userID", userID)
+		c.Set("userRole", models.RoleAdmin)
+		c.Next()
+	})
+	router.POST("/events", handler.CreateEvent)
+	return router
+}
+
+func TestCreateEventForcesCreatorIntoAdmins(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{}
+	redisStore := &mocks.MockRedisStore{}
+	router := newCreateEventTestRouter(mongoStore, redisStore, "creator-1")
+
+	body := []byte(`{
+		"id": "event-1",
+		"name": "Hack Night",
+		"date": "2026-05-01",
+		"time": "18:00",
+		"location": "SCE",
+		"description": "Build things",
+		"admins": ["admin-2"],
+		"registration_form": [],
+		"max_attendees": -1,
+		"created_at": "2026-04-28T00:00:00Z",
+		"waitlist_enabled": false
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if mongoStore.CreatedEvent == nil {
+		t.Fatal("expected event to be created")
+	}
+	expectedAdmins := []string{"admin-2", "creator-1"}
+	if !reflect.DeepEqual(mongoStore.CreatedEvent.Admins, expectedAdmins) {
+		t.Fatalf("expected admins %v, got %v", expectedAdmins, mongoStore.CreatedEvent.Admins)
+	}
+	if redisStore.SetCalled {
+		t.Fatal("did not expect Redis headcount for unlimited event")
+	}
+}
+
+func TestCreateEventDedupesCreatorAdmin(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{}
+	redisStore := &mocks.MockRedisStore{}
+	router := newCreateEventTestRouter(mongoStore, redisStore, "creator-1")
+
+	body := []byte(`{
+		"id": "event-1",
+		"name": "Hack Night",
+		"date": "2026-05-01",
+		"time": "18:00",
+		"location": "SCE",
+		"description": "Build things",
+		"admins": [" creator-1 ", "admin-2", "creator-1"],
+		"registration_form": [],
+		"max_attendees": 20,
+		"created_at": "2026-04-28T00:00:00Z",
+		"waitlist_enabled": false
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", w.Code, w.Body.String())
+	}
+	expectedAdmins := []string{"creator-1", "admin-2"}
+	if !reflect.DeepEqual(mongoStore.CreatedEvent.Admins, expectedAdmins) {
+		t.Fatalf("expected admins %v, got %v", expectedAdmins, mongoStore.CreatedEvent.Admins)
+	}
+	if !redisStore.SetCalled || redisStore.SetCapacity != 20 {
+		t.Fatalf("expected Redis headcount capacity 20, got called=%v capacity=%d", redisStore.SetCalled, redisStore.SetCapacity)
+	}
+}
+
+func TestCreateEventRejectsMissingCreatorID(t *testing.T) {
+	mongoStore := &mocks.MockMongoStore{}
+	redisStore := &mocks.MockRedisStore{}
+	router := newCreateEventTestRouter(mongoStore, redisStore, "")
+
+	body := []byte(`{
+		"id": "event-1",
+		"name": "Hack Night",
+		"date": "2026-05-01",
+		"time": "18:00",
+		"location": "SCE",
+		"description": "Build things",
+		"admins": ["admin-2"],
+		"registration_form": [],
+		"max_attendees": -1,
+		"created_at": "2026-04-28T00:00:00Z",
+		"waitlist_enabled": false
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d: %s", w.Code, w.Body.String())
+	}
+	if mongoStore.CreatedEvent != nil {
+		t.Fatal("did not expect event to be created")
+	}
+}
+
 
 func newTestHandler(redis db.RedisStore) *EventHandler {
 	return &EventHandler{

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -41,6 +41,7 @@ func RequireAuth(minimumState int, clientAPIURL string) gin.HandlerFunc {
 
 		c.Set("userID", userID)
 		c.Set("userRole", role)
+		c.Set("accessLevel", accessLevel)
 		c.Next()
 	}
 }
@@ -100,7 +101,7 @@ func OptionalAuth(clientAPIURL string) gin.HandlerFunc {
 			return
 		}
 
-		userID, role, _, err := verifyAuthHeader(authHeader, clientAPIURL)
+		userID, role, accessLevel, err := verifyAuthHeader(authHeader, clientAPIURL)
 		if err != nil {
 			// if not success, the token was invalid or the API is down
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Token verification failed"})
@@ -109,6 +110,7 @@ func OptionalAuth(clientAPIURL string) gin.HandlerFunc {
 
 		c.Set("userID", userID)
 		c.Set("userRole", role)
+		c.Set("accessLevel", accessLevel)
 		c.Next()
 	}
 }

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -16,9 +16,11 @@ func setupRouter(minimumState int, clientAPIURL string) *gin.Engine {
 	r.GET("/test", func(c *gin.Context) {
 		userID, _ := c.Get("userID")
 		userRole, _ := c.Get("userRole")
+		accessLevel, _ := c.Get("accessLevel")
 		c.JSON(http.StatusOK, gin.H{
-			"userID":   userID,
-			"userRole": userRole,
+			"userID":      userID,
+			"userRole":    userRole,
+			"accessLevel": accessLevel,
 		})
 	})
 	return r
@@ -65,6 +67,17 @@ func TestRequireAuth(t *testing.T) {
 				"accessLevel": float64(MembershipStatePending),
 			},
 			minimumState:   MembershipStateMember,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:       "officer token fails admin requirement",
+			authHeader: "Bearer valid-token",
+			mockAPIStatus: http.StatusOK,
+			mockAPIResponse: map[string]interface{}{
+				"_id":         "officer-1",
+				"accessLevel": float64(MembershipStateOfficer),
+			},
+			minimumState:   MembershipStateAdmin,
 			expectedStatus: http.StatusForbidden,
 		},
 		{
@@ -128,14 +141,14 @@ func TestRequireAuth(t *testing.T) {
 			}
 
 			if w.Code == http.StatusOK {
-				var response map[string]string
+				var response map[string]interface{}
 				_ = json.Unmarshal(w.Body.Bytes(), &response)
-				
+
 				if response["userID"] != tt.expectedUserID {
-					t.Errorf("expected userID %s, got %s", tt.expectedUserID, response["userID"])
+					t.Errorf("expected userID %s, got %v", tt.expectedUserID, response["userID"])
 				}
 				if response["userRole"] != tt.expectedRole {
-					t.Errorf("expected userRole %s, got %s", tt.expectedRole, response["userRole"])
+					t.Errorf("expected userRole %s, got %v", tt.expectedRole, response["userRole"])
 				}
 			}
 		})
@@ -149,9 +162,11 @@ func setupOptionalAuthRouter(clientAPIURL string) *gin.Engine {
 	r.GET("/test", func(c *gin.Context) {
 		userID, _ := c.Get("userID")
 		userRole, _ := c.Get("userRole")
+		accessLevel, _ := c.Get("accessLevel")
 		c.JSON(http.StatusOK, gin.H{
-			"userID":   userID,
-			"userRole": userRole,
+			"userID":      userID,
+			"userRole":    userRole,
+			"accessLevel": accessLevel,
 		})
 	})
 	return r
@@ -215,16 +230,19 @@ func TestOptionalAuth_SetsContextForValidToken(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", w.Code)
 	}
 
-	var response map[string]string
+	var response map[string]interface{}
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("expected valid JSON, got %v", err)
 	}
 
 	if response["userID"] != "user-123" {
-		t.Fatalf("expected userID user-123, got %s", response["userID"])
+		t.Fatalf("expected userID user-123, got %v", response["userID"])
 	}
 	if response["userRole"] != "User" {
-		t.Fatalf("expected userRole User, got %s", response["userRole"])
+		t.Fatalf("expected userRole User, got %v", response["userRole"])
+	}
+	if int(response["accessLevel"].(float64)) != MembershipStateMember {
+		t.Fatalf("expected accessLevel 1, got %v", response["accessLevel"])
 	}
 }
 

--- a/pkg/mocks/mongo.go
+++ b/pkg/mocks/mongo.go
@@ -29,6 +29,7 @@ type MockMongoStore struct {
 	WaitlistedEventIDsErr      error
 	Events                     []models.Event
 	EventsErr                  error
+	CreatedEvent               *models.Event
 }
 
 func (m *MockMongoStore) GetEvents(_ context.Context, _, _ string) ([]models.Event, error) {
@@ -38,6 +39,7 @@ func (m *MockMongoStore) GetEventByID(_ context.Context, _ string) (*models.Even
 	return m.Event, m.EventErr
 }
 func (m *MockMongoStore) CreateEvent(_ context.Context, e models.Event) (*models.Event, error) {
+	m.CreatedEvent = &e
 	return &e, nil
 }
 func (m *MockMongoStore) DeleteEventByID(_ context.Context, _ string) error {

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -391,8 +391,31 @@ func (e *Event) ApplyPatch(fields map[string]interface{}) error {
 			e.RegistrationForm = questions
 
 		case "admins":
-			// supported by persistence model, but not yet patchable here
-			return fmt.Errorf("%s cannot be updated through this endpoint yet", key)
+			arr, ok := value.([]interface{})
+			if !ok {
+				return fmt.Errorf("admins must be an array")
+			}
+			seen := make(map[string]struct{}, len(arr))
+			admins := make([]string, 0, len(arr))
+			for i, item := range arr {
+				admin, ok := item.(string)
+				if !ok {
+					return fmt.Errorf("admins[%d] must be a string", i)
+				}
+				admin = strings.TrimSpace(admin)
+				if admin == "" {
+					return fmt.Errorf("admins[%d] cannot be empty", i)
+				}
+				if _, exists := seen[admin]; exists {
+					continue
+				}
+				seen[admin] = struct{}{}
+				admins = append(admins, admin)
+			}
+			if len(admins) == 0 {
+				return fmt.Errorf("admins must include at least one user")
+			}
+			e.Admins = admins
 		}
 	}
 

--- a/pkg/models/event_test.go
+++ b/pkg/models/event_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -383,14 +384,77 @@ func TestApplyPatch(t *testing.T) {
 	if err := e.ApplyPatch(invalidFields); err == nil {
 		t.Errorf("expected error for invalid type")
 	}
-	
-	unpatchableFields := map[string]interface{}{
-		"admins": []string{"admin1"},
+}
+
+func TestApplyPatch_Admins(t *testing.T) {
+	e := &Event{
+		Admins: []string{"admin-old"},
 	}
-	if err := e.ApplyPatch(unpatchableFields); err == nil {
-		t.Errorf("expected error for unpatchable field admins")
+
+	fields := map[string]interface{}{
+		"admins": []interface{}{" admin-1 ", "admin-2", "admin-1"},
+	}
+
+	if err := e.ApplyPatch(fields); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	expected := []string{"admin-1", "admin-2"}
+	if !reflect.DeepEqual(e.Admins, expected) {
+		t.Errorf("expected admins %v, got %v", expected, e.Admins)
 	}
 }
+
+func TestApplyPatch_AdminsRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		fields  map[string]interface{}
+		wantErr string
+	}{
+		{
+			name: "not an array",
+			fields: map[string]interface{}{
+				"admins": "admin-1",
+			},
+			wantErr: "admins must be an array",
+		},
+		{
+			name: "empty array",
+			fields: map[string]interface{}{
+				"admins": []interface{}{},
+			},
+			wantErr: "admins must include at least one user",
+		},
+		{
+			name: "blank admin",
+			fields: map[string]interface{}{
+				"admins": []interface{}{"admin-1", " "},
+			},
+			wantErr: "admins[1] cannot be empty",
+		},
+		{
+			name: "non-string admin",
+			fields: map[string]interface{}{
+				"admins": []interface{}{"admin-1", float64(2)},
+			},
+			wantErr: "admins[1] must be a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Event{Admins: []string{"admin-old"}}
+			err := e.ApplyPatch(tt.fields)
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
+			}
+			if err.Error() != tt.wantErr {
+				t.Fatalf("expected error %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
 
 func TestApplyPatch_RegistrationForm(t *testing.T) {
 	e := &Event{


### PR DESCRIPTION
# PR for #98 

## **Problem**
Event creation allowed admins to create and edit their own events but there was no way for other admins to be able to edit events they didn't create. There should be a way for the event's original creator to add and remove admins who can edit their event. 

## **Solution**
- Moved `POST /events` (CreateEvent) into a new admin-protected route group requiring `MembershipStateAdmin`
- CreateEvent handler now extracts the creator's user ID from the auth context and ensures it's always included in the admins list with deduplication
- Enabled the `admins` field in `ApplyPatch` so event updates can modify the admin list with validation (type checking, dedup, non-empty)
- Added `accessLevel` to the Gin context in both `RequireAuth` and `OptionalAuth` middleware

## **Files Changed**
| File | Change |
|------|--------|
| `cmd/server/main.go` | New admin-protected route group for event creation |
| `pkg/handlers/event.go` | Creator forced into admins, admins passthrough on update |
| `pkg/handlers/event_test.go` | Tests for creator admin inclusion and dedup |
| `pkg/middleware/auth.go` | Expose `accessLevel` in context |
| `pkg/middleware/auth_test.go` | Tests for accessLevel and admin auth rejection |
| `pkg/models/event.go` | Enable admins patching with validation |
| `pkg/models/event_test.go` | Tests for admins patch cases |
| `pkg/mocks/mongo.go` | Track created event in mock for test assertions |