### PR TITLE
Create integration and load tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,33 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Compose can be slow on runners (Kafka + topic init + server build)
+      INTEGRATION_READY_TIMEOUT: 120s
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # make integration = docker compose up + go test -tags=integration (see testing/Makefile)
+      - name: Run integration tests
+        run: make integration
+
+      - name: Tear down Compose
+        if: always()
+        run: make teardown-integration

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Forward integration/load targets to testing/Makefile so paths stay correct.
+# From repo root: `make integration`, `make load`, `make integration TEST=register`, etc.
+
+REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: integration load teardown teardown-integration teardown-load
+
+integration load teardown teardown-integration teardown-load:
+	@$(MAKE) -f "$(REPO_ROOT)/testing/Makefile" $(MAKECMDGOALS)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,8 +37,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      kafka:
-        condition: service_started
+      kafka-init:
+        condition: service_completed_successfully
     environment:
       - MONGO_URI=${MONGO_URI:-mongodb://mongodb:27017}
       - REDIS_ADDR=${REDIS_ADDR:-redis:6379}

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,0 +1,60 @@
+# Paths follow this Makefile location (not cwd), so you can run:
+#   make -f testing/Makefile integration
+# from the repo root, or from anywhere via absolute -f path.
+_TESTING_ABS := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT     := $(abspath $(_TESTING_ABS)/..)
+COMPOSE_BASE     := $(REPO_ROOT)/docker-compose.dev.yml
+COMPOSE_INT      := $(REPO_ROOT)/testing/integration/docker-compose.integration.yml
+COMPOSE_LOAD     := $(REPO_ROOT)/testing/load/docker-compose.load.yml
+INTEGRATION_DIR  := $(REPO_ROOT)/testing/integration
+LOAD_DIR         := $(REPO_ROOT)/testing/load
+
+# Default to running all integration tests if no filter is provided
+TEST ?= all
+
+.PHONY: integration load teardown teardown-integration teardown-load _up_integration _up_load
+
+# Tear down Compose stacks (absolute -f paths; works from any cwd).
+teardown-integration:
+	docker compose --project-directory "$(REPO_ROOT)" -f $(COMPOSE_BASE) -f $(COMPOSE_INT) down
+
+teardown-load:
+	docker compose --project-directory "$(REPO_ROOT)" -f $(COMPOSE_BASE) -f $(COMPOSE_LOAD) down
+
+teardown: teardown-integration teardown-load
+
+# Run integration tests.
+# Usage:
+#   make integration                  (runs full suite)
+#   make integration TEST=register    (registration flow only)
+#   make integration TEST=create      (event creation flow only)
+integration: _up_integration
+ifeq ($(TEST),register)
+	cd $(INTEGRATION_DIR) && go test -tags=integration -v -run TestRegistration ./...
+else ifeq ($(TEST),create)
+	cd $(INTEGRATION_DIR) && go test -tags=integration -v -run TestEventCreation ./...
+else
+	cd $(INTEGRATION_DIR) && go test -tags=integration -v ./...
+endif
+
+# Flood the registration endpoint with concurrent requests via k6
+load: _up_load
+	k6 run $(LOAD_DIR)/register.js
+
+# ── internal targets ──────────────────────────────────────────────────────────
+
+# Spin up the stack with mock Clark for integration tests (leaves containers running)
+_up_integration:
+	docker compose \
+		--project-directory "$(REPO_ROOT)" \
+		-f $(COMPOSE_BASE) \
+		-f $(COMPOSE_INT) \
+		up -d --build
+
+# Spin up the stack with mock Clark for load tests (leaves containers running)
+_up_load:
+	docker compose \
+		--project-directory "$(REPO_ROOT)" \
+		-f $(COMPOSE_BASE) \
+		-f $(COMPOSE_LOAD) \
+		up -d --build

--- a/testing/integration/creation_test.go
+++ b/testing/integration/creation_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestEventCreationFlow_CreateAndRetrieve creates an event and verifies it can be
+// fetched back with matching fields.
+func TestEventCreationFlow_CreateAndRetrieve(t *testing.T) {
+	body := defaultEvent("Create And Retrieve Test", 50)
+	eventID := createEvent(t, "admin-create-retrieve", body)
+
+	resp, err := http.Get(baseURL() + "/events/" + eventID)
+	if err != nil {
+		t.Fatalf("GET event failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET event: expected 200, got %d", resp.StatusCode)
+	}
+
+	var event map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&event)
+
+	if event["id"] != eventID {
+		t.Errorf("expected id %q, got %q", eventID, event["id"])
+	}
+	if event["name"] != body["name"] {
+		t.Errorf("expected name %q, got %q", body["name"], event["name"])
+	}
+	if event["location"] != body["location"] {
+		t.Errorf("expected location %q, got %q", body["location"], event["location"])
+	}
+}
+
+// TestEventCreationFlow_Update creates an event, patches the name and location,
+// then verifies the updated values are returned.
+func TestEventCreationFlow_Update(t *testing.T) {
+	eventID := createEvent(t, "admin-update", defaultEvent("Update Test Original", 50))
+
+	patch, _ := json.Marshal(map[string]interface{}{
+		"name":     "Update Test Renamed",
+		"location": "New Venue",
+	})
+	req, _ := http.NewRequest(http.MethodPatch, baseURL()+"/events/"+eventID, bytes.NewReader(patch))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader("admin-update"))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH event failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH event: expected 200, got %d", resp.StatusCode)
+	}
+
+	// verify via GET
+	resp, err = http.Get(baseURL() + "/events/" + eventID)
+	if err != nil {
+		t.Fatalf("GET after PATCH failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var event map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&event)
+
+	if event["name"] != "Update Test Renamed" {
+		t.Errorf("expected updated name, got %q", event["name"])
+	}
+	if event["location"] != "New Venue" {
+		t.Errorf("expected updated location, got %q", event["location"])
+	}
+}
+
+// TestEventCreationFlow_Delete creates an event, deletes it, and verifies a
+// subsequent GET returns 404. Only draft or closed events may be deleted (see DeleteEventByID).
+func TestEventCreationFlow_Delete(t *testing.T) {
+	body := defaultEvent("Delete Test", 50)
+	body["status"] = "draft"
+	eventID := createEvent(t, "admin-delete", body)
+
+	req, _ := http.NewRequest(http.MethodDelete, baseURL()+"/events/"+eventID, nil)
+	req.Header.Set("Authorization", authHeader("admin-delete"))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE event failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE event: expected 200, got %d", resp.StatusCode)
+	}
+
+	// verify the event is gone
+	resp, err = http.Get(baseURL() + "/events/" + eventID)
+	if err != nil {
+		t.Fatalf("GET after DELETE failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 after deletion, got %d", resp.StatusCode)
+	}
+}

--- a/testing/integration/docker-compose.integration.yml
+++ b/testing/integration/docker-compose.integration.yml
@@ -1,0 +1,17 @@
+services:
+  mock-clark:
+    build:
+      context: ./testing/integration/mock_clark
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+
+  server:
+    environment:
+      - CLIENT_API_URL=http://mock-clark:8080
+    depends_on:
+      mock-clark:
+        condition: service_healthy

--- a/testing/integration/go.mod
+++ b/testing/integration/go.mod
@@ -1,0 +1,3 @@
+module github.com/SCE-Development/SCEvents/testing/integration
+
+go 1.21

--- a/testing/integration/helpers_test.go
+++ b/testing/integration/helpers_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+func baseURL() string {
+	if u := os.Getenv("SERVICE_URL"); u != "" {
+		return u
+	}
+	return "http://localhost:8002"
+}
+
+func authHeader(userID string) string {
+	return "Bearer " + userID
+}
+
+// createEvent POSTs to /events/ and returns the created event's ID.
+// Uses the provided userID as both the Bearer token and event admin.
+func createEvent(t interface {
+	Helper()
+	Fatalf(string, ...interface{})
+}, userID string, body map[string]interface{}) string {
+	t.Helper()
+
+	// Ensure the creator can edit/delete in follow-up tests.
+	if _, ok := body["admins"]; !ok {
+		body["admins"] = []interface{}{userID}
+	}
+
+	data, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPost, baseURL()+"/events/", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(userID))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("createEvent request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		t.Fatalf("createEvent: expected 201, got %d", resp.StatusCode)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	id, ok := result["id"].(string)
+	if !ok || id == "" {
+		t.Fatalf("createEvent: response missing id field: %v", result)
+	}
+	return id
+}
+
+// registerForEvent POSTs to /events/:id/register and returns (statusCode, requestID).
+func registerForEvent(eventID, userID, name, email string) (int, string) {
+	body, _ := json.Marshal(map[string]interface{}{
+		"registrant": map[string]interface{}{
+			"name":    name,
+			"email":   email,
+			"user_id": userID,
+		},
+		"registration_form_answers": map[string]interface{}{},
+	})
+
+	req, _ := http.NewRequest(http.MethodPost, baseURL()+"/events/"+eventID+"/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader(userID))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, ""
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	requestID, _ := result["request_id"].(string)
+	return resp.StatusCode, requestID
+}
+
+// pollRegistrationStatus polls GET /events/registrations/:request_id?user_id=:userID
+// until the status is no longer "pending" or the timeout is exceeded.
+func pollRegistrationStatus(requestID, userID string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL() + "/events/registrations/" + requestID + "?user_id=" + userID)
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
+		var result map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+
+		status, _ := result["status"].(string)
+		if status != "" && status != "pending" {
+			return status, nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return "", fmt.Errorf("timed out after %s waiting for registration %s to be processed", timeout, requestID)
+}
+
+// defaultEvent returns a minimal valid event body with the given name and capacity.
+func defaultEvent(name string, maxAttendees int) map[string]interface{} {
+	return map[string]interface{}{
+		"name":              name,
+		"date":              "2099-12-31",
+		"time":              "18:00",
+		"location":          "Test Venue",
+		"description":       "Integration test event",
+		"max_attendees":     maxAttendees,
+		"status":            "published",
+		"visibility":        "public",
+		"registration_form": []interface{}{},
+	}
+}

--- a/testing/integration/main_test.go
+++ b/testing/integration/main_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	if err := waitForService(baseURL()+"/ping", readyDeadline()); err != nil {
+		fmt.Fprintf(os.Stderr, "service not ready: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
+func readyDeadline() time.Time {
+	d := 90 * time.Second
+	if s := os.Getenv("INTEGRATION_READY_TIMEOUT"); s != "" {
+		if dur, err := time.ParseDuration(s); err == nil && dur > 0 {
+			d = dur
+		}
+	}
+	return time.Now().Add(d)
+}
+
+func waitForService(url string, deadline time.Time) error {
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("timed out waiting for %s", url)
+}

--- a/testing/integration/mock_clark/Dockerfile
+++ b/testing/integration/mock_clark/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY main.go .
+RUN go mod init mock_clark && go build -o mock_clark .
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=builder /app/mock_clark .
+EXPOSE 8080
+CMD ["./mock_clark"]

--- a/testing/integration/mock_clark/main.go
+++ b/testing/integration/mock_clark/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// Mock Clark auth server for use in integration and load tests.
+// Echoes the Bearer token as _id with accessLevel 3 (admin). Create/update/delete
+// routes require MembershipStateOfficer (2), so the mock must be at least officer.
+func main() {
+	http.HandleFunc("/api/Auth/verify", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		auth := r.Header.Get("Authorization")
+		userID := strings.TrimPrefix(auth, "Bearer ")
+		if userID == "" {
+			http.Error(w, "missing token", http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"_id":         userID,
+			"accessLevel": 3,
+		})
+	})
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	log.Println("mock Clark API listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/testing/integration/registration_test.go
+++ b/testing/integration/registration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func isRegistrationSubmitted(status int) bool {
+	return status == http.StatusCreated || status == http.StatusAccepted
+}
+
+// TestRegistrationFlow_BasicRegistration creates an event, registers a user,
+// and verifies the registration is accepted by the Kafka consumer.
+func TestRegistrationFlow_BasicRegistration(t *testing.T) {
+	eventID := createEvent(t, "admin-basic-reg", defaultEvent("Basic Registration Test", 100))
+
+	status, requestID := registerForEvent(eventID, "user-basic-reg", "Alice Smith", "alice@example.com")
+	if !isRegistrationSubmitted(status) {
+		t.Fatalf("expected 201/202 for registration submission, got %d", status)
+	}
+	if requestID == "" {
+		t.Fatal("expected non-empty request_id in response")
+	}
+
+	finalStatus, err := pollRegistrationStatus(requestID, "user-basic-reg", 10*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if finalStatus != "accepted" {
+		t.Errorf("expected registration status 'accepted', got %q", finalStatus)
+	}
+}
+
+// TestRegistrationFlow_DuplicateRegistration verifies that registering the same
+// user for the same event twice is rejected with 409.
+func TestRegistrationFlow_DuplicateRegistration(t *testing.T) {
+	eventID := createEvent(t, "admin-dup-reg", defaultEvent("Duplicate Registration Test", 100))
+
+	// first registration
+	status, requestID := registerForEvent(eventID, "user-dup-reg", "Bob Jones", "bob@example.com")
+	if !isRegistrationSubmitted(status) {
+		t.Fatalf("first registration: expected 201/202, got %d", status)
+	}
+
+	// wait for the first to be accepted so we're in an accepted state, not just pending
+	if _, err := pollRegistrationStatus(requestID, "user-dup-reg", 10*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	// second registration — same user, same event
+	status, _ = registerForEvent(eventID, "user-dup-reg", "Bob Jones", "bob@example.com")
+	if status != http.StatusConflict {
+		t.Errorf("duplicate registration: expected 409 Conflict, got %d", status)
+	}
+}
+
+// TestRegistrationFlow_CapacityFull creates an event with capacity 1, fills it,
+// then verifies a second user's registration is rejected as capacity_full.
+func TestRegistrationFlow_CapacityFull(t *testing.T) {
+	eventID := createEvent(t, "admin-cap-full", defaultEvent("Capacity Full Test", 1))
+
+	// register first user — should be accepted
+	status, requestID := registerForEvent(eventID, "user-cap-first", "Carol White", "carol@example.com")
+	if !isRegistrationSubmitted(status) {
+		t.Fatalf("first registration: expected 201/202, got %d", status)
+	}
+	firstStatus, err := pollRegistrationStatus(requestID, "user-cap-first", 10*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstStatus != "accepted" {
+		t.Fatalf("first registration: expected 'accepted', got %q", firstStatus)
+	}
+
+	// register second user — event is full, should be rejected immediately
+	status, requestID = registerForEvent(eventID, "user-cap-second", "Dave Green", "dave@example.com")
+	if status != http.StatusConflict {
+		t.Fatalf("second registration: expected 409 Conflict when full, got %d", status)
+	}
+	if requestID != "" {
+		secondStatus, err := pollRegistrationStatus(requestID, "user-cap-second", 10*time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if secondStatus != "rejected" {
+			t.Errorf("second registration: expected 'rejected' (capacity_full), got %q", secondStatus)
+		}
+	}
+}

--- a/testing/load/docker-compose.load.yml
+++ b/testing/load/docker-compose.load.yml
@@ -1,0 +1,17 @@
+services:
+  mock-clark:
+    build:
+      context: ./testing/integration/mock_clark
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+
+  server:
+    environment:
+      - CLIENT_API_URL=http://mock-clark:8080
+    depends_on:
+      mock-clark:
+        condition: service_healthy

--- a/testing/load/register.js
+++ b/testing/load/register.js
@@ -1,0 +1,105 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8002';
+
+export const options = {
+  scenarios: {
+    registration_flood: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 100 },   // ramp up to 100
+        { duration: '1m',  target: 500 },   // ramp up to 500
+        { duration: '30s', target: 1000 },  // peak at 1000
+        { duration: '30s', target: 0 },     // ramp down
+      ],
+    },
+  },
+  thresholds: {
+    // 95th percentile response time under 2 seconds
+    http_req_duration: ['p(95)<2000'],
+    // less than 5% of requests should fail (non-2xx or network error)
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+// setup() runs once before any VUs start.
+// Creates a handful of events with large capacity to spread load across.
+export function setup() {
+  const adminToken = 'load-test-admin';
+  const headers = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${adminToken}`,
+  };
+
+  const eventIDs = [];
+  for (let i = 0; i < 5; i++) {
+    const res = http.post(
+      `${BASE_URL}/events/`,
+      JSON.stringify({
+        name: `Load Test Event ${i + 1}`,
+        date: '2099-12-31',
+        time: '18:00',
+        location: 'Load Test Venue',
+        description: 'Created by k6 load test — safe to delete',
+        max_attendees: 100000,
+        status: 'published',
+        visibility: 'public',
+        registration_form: [],
+      }),
+      { headers }
+    );
+
+    if (res.status === 201 || res.status === 200) {
+      const body = JSON.parse(res.body);
+      if (body.id) {
+        eventIDs.push(body.id);
+      }
+    }
+  }
+
+  if (eventIDs.length === 0) {
+    throw new Error('setup failed: could not create any test events');
+  }
+
+  console.log(`setup: created ${eventIDs.length} events`);
+  return { eventIDs };
+}
+
+// default function runs for every VU iteration.
+// Each VU+iteration gets a unique token so mock Clark issues a unique user_id,
+// avoiding duplicate-registration conflicts.
+export default function ({ eventIDs }) {
+  const userToken = `load-test-user-${__VU}-${__ITER}`;
+  // Spread load evenly across the seeded events
+  const eventID = eventIDs[__VU % eventIDs.length];
+
+  const res = http.post(
+    `${BASE_URL}/events/${eventID}/register`,
+    JSON.stringify({
+      registrant: {
+        name: `Load Test User ${__VU}`,
+        email: `loadtest-${__VU}-${__ITER}@example.com`,
+        user_id: userToken,
+      },
+      registration_form_answers: {},
+    }),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${userToken}`,
+      },
+    }
+  );
+
+  check(res, {
+    'registration accepted (202)': (r) => r.status === 202,
+    'response has request_id': (r) => {
+      try { return !!JSON.parse(r.body).request_id; } catch { return false; }
+    },
+  });
+
+  // small think time to avoid thundering herd on first iteration
+  sleep(0.1);
+}

--- a/testing/testing.md
+++ b/testing/testing.md
@@ -1,0 +1,26 @@
+# Testing Guide
+
+## Usage
+
+To run integration tests:
+
+```bash
+make integration
+make integration TEST=create   # runs event creation flow
+make integration TEST=register # runs registration flow
+```
+
+Must install K6 to run load tests.
+To run load tests:
+
+```bash
+make load
+```
+
+These commands spin up Docker Compose (dev base + integration or load overrides). Containers stay running so you can inspect logs or state before teardown.
+
+```bash
+make teardown                     # integration + load stacks
+make teardown-integration          # integration stack only
+make teardown-load                 # load stack only
+```


### PR DESCRIPTION
Resolves #57 
Resolves #56 

This PR introduces a testing framework for SCEvents, covering both:

- Integration testing for correctness of core event and registration flows via Make targets.
- High-concurrency load testing with k6 to validate system behavior under stress.

It also adds a repeatable, Docker-based local testing setup with standardized commands for running and tearing down tests.

## Directory layout
testing/
  ├── Makefile                                  # make integration_reg / integration_event / integration_all / load_reg
  ├── integration/
  │   ├── go.mod                                # separate module, stdlib only
  │   ├── mock_clark/
  │   │   ├── main.go                           # fake Clark: echoes Bearer token as user _id
  │   │   └── Dockerfile
  │   ├── docker-compose.integration.yml        # adds mock-clark, overrides CLIENT_API_URL
  │   ├── main_test.go                          # TestMain: waits for /ping
  │   ├── helpers_test.go                       # helper funcs for integration tests
  │   ├── registration_test.go                  # registration flow coverage
  │   └── creation_test.go                      # create/retrieve/update/delete coverage

tests/
  └── load_testing/
      ├── docker-compose.load.yml               # load-test compose override
      ├── register_flood.js                     # k6 registration flood scenario
      └── README.md                             # load-test usage and thresholds

## Auth strategy in tests

`mock_clark` accepts any `Bearer <token>` and returns:

```json
{"_id":"<token>","accessLevel":1}
```

Each test uses a unique token (for example, `user-basic-reg`), so user identity is controlled by the token value without requiring a real Clark instance.

## Commands (run from `testing/`)

### Integration testing
make integration_reg
make integration_event
make integration_all

### Load testing 

make load_reg

## Teardown

Integration stack:

docker compose -f ../docker-compose.dev.yml -f integration/docker-compose.integration.yml down

Load-test stack:

docker compose -f ../docker-compose.dev.yml -f ../tests/load_testing/docker-compose.load.yml down

Containers stay running after each command so you can inspect state before teardown.