### PR TITLE
Implement registration/me endpoint and fix auth middleware

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -119,6 +119,7 @@ func main() {
 			protected.GET("/:id/attendance", eventHandler.GetEventAttendanceSummary)
 			protected.GET("/:id/registrations", eventHandler.ListEventRegistrations)
 			protected.GET("/:id/registrations/:request_id", eventHandler.GetEventRegistrationByRequestID)
+			protected.GET("/:id/registration/me", eventHandler.GetMyRegistrationState)
 			protected.POST("/:id/register", eventHandler.RegisterForEvent(producer))
 			protected.POST("/:id/waitlist", eventHandler.JoinEventWaitlist)
 			protected.GET("/:id/attendees", eventHandler.GetEventAttendees)

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -1124,3 +1124,35 @@ func (h *EventHandler) GetEventRegistrationByRequestID(c *gin.Context) {
 
 	c.JSON(http.StatusOK, registrationReq)
 }
+
+func (h *EventHandler) GetMyRegistrationState(c *gin.Context) {
+	eventID := strings.TrimSpace(c.Param("id"))
+	if eventID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "event id is required"})
+		return
+	}
+
+	userID := strings.TrimSpace(c.GetString("userID"))
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "login required"})
+		return
+	}
+
+	eventIDs := []string{eventID}
+	registrationStatuses, err := h.stores.Mongo.GetRegistrationStatusesForUser(c.Request.Context(), userID, eventIDs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch registration status"})
+		return
+	}
+
+	waitlistedEventIDs, err := h.stores.Mongo.GetWaitlistedEventIDsForUser(c.Request.Context(), userID, eventIDs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch waitlist status"})
+		return
+	}
+
+	status := resolveEventRegistrationStatus(eventID, registrationStatuses, waitlistedEventIDs)
+	c.JSON(http.StatusOK, gin.H{
+		"registration_status": status,
+	})
+}


### PR DESCRIPTION
- I think some thing broken at registration me and auth middle

The frontend was getting 404 Not Found when trying to check your registration status.

The Cause: The endpoint GET /events/:id/registration/me simply didn't exist in the Go backend code.