### PR TITLE
Add protected attendees endpoint for events

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -121,6 +121,7 @@ func main() {
 			protected.GET("/:id/registrations/:request_id", eventHandler.GetEventRegistrationByRequestID)
 			protected.POST("/:id/register", eventHandler.RegisterForEvent(producer))
 			protected.POST("/:id/waitlist", eventHandler.JoinEventWaitlist)
+			protected.GET("/:id/attendees", eventHandler.GetEventAttendees)
 		}
 
 		officerProtected := events.Group("/")

--- a/pkg/db/registration.go
+++ b/pkg/db/registration.go
@@ -454,3 +454,30 @@ func (s *mongoStore) GetRegistrationStatusesForUser(ctx context.Context, userID 
 
 	return result, nil
 }
+
+// returns all accepted registrations for a given event.
+func (s *mongoStore) ListAcceptedRegistrationsForEvent(ctx context.Context, eventID string) ([]models.RegistrationRequest, error) {
+	filter := bson.M{
+		"event_id": eventID,
+		"status":   models.StatusAccepted,
+	}
+
+	opts := options.Find().SetSort(bson.D{
+		{Key: "created_at", Value: 1},
+	})
+
+	cursor, err := s.registrations.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = cursor.Close(ctx)
+	}()
+
+	registrations := make([]models.RegistrationRequest, 0)
+	if err := cursor.All(ctx, &registrations); err != nil {
+		return nil, err
+	}
+
+	return registrations, nil
+}

--- a/pkg/db/stores.go
+++ b/pkg/db/stores.go
@@ -48,6 +48,7 @@ type MongoStore interface {
 	CountWaitlistEntries(ctx context.Context, eventID string) (int64, error)
 	CreateWaitlistEntry(ctx context.Context, entry models.WaitlistEntry) error
 	GetWaitlistedEventIDsForUser(ctx context.Context, userID string, eventIDs []string) (map[string]bool, error)
+	ListAcceptedRegistrationsForEvent(ctx context.Context, eventID string) ([]models.RegistrationRequest, error)
 }
 
 type Stores struct {

--- a/pkg/handlers/event.go
+++ b/pkg/handlers/event.go
@@ -240,6 +240,104 @@ func (h *EventHandler) GetEventAttendanceSummary(c *gin.Context) {
 	})
 }
 
+type PublicAttendee struct {
+	UserID string `json:"user_id"`
+	Name   string `json:"name"`
+}
+
+// converts a full name into a privacy-safer display form.
+func formatPublicAttendeeName(fullName string) string {
+	fullName = strings.TrimSpace(fullName)
+	if fullName == "" {
+		return "Registered attendee"
+	}
+
+	parts := strings.Fields(fullName)
+	if len(parts) == 1 {
+		return parts[0]
+	}
+
+	last := []rune(parts[len(parts)-1])
+	if len(last) == 0 {
+		return parts[0]
+	}
+
+	return parts[0] + " " + string(last[0]) + "."
+}
+
+// returns a privacy-safe attendee list for authorized users only.
+func (h *EventHandler) GetEventAttendees(c *gin.Context) {
+	eventID := strings.TrimSpace(c.Param("id"))
+	if eventID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "event id is required",
+		})
+		return
+	}
+
+	userID := strings.TrimSpace(c.GetString("userID"))
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "login required",
+		})
+		return
+	}
+	userRole := strings.TrimSpace(c.GetString("userRole"))
+
+	event, err := h.stores.Mongo.GetEventByID(c.Request.Context(), eventID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "event not found",
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch event",
+		})
+		return
+	}
+	canView := event.CanEdit(userID, userRole)
+	if !canView {
+		hasAccepted, err := h.stores.Mongo.HasAcceptedRegistration(c.Request.Context(), eventID, userID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to verify attendee access",
+			})
+			return
+		}
+		canView = hasAccepted
+	}
+
+	if !canView {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "only registered attendees and event organizers can view the attendee list",
+		})
+		return
+	}
+
+	registrations, err := h.stores.Mongo.ListAcceptedRegistrationsForEvent(c.Request.Context(), eventID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to fetch attendees",
+		})
+		return
+	}
+
+	attendees := make([]PublicAttendee, 0, len(registrations))
+	for _, r := range registrations {
+		attendees = append(attendees, PublicAttendee{
+			UserID: strings.TrimSpace(r.Registrant.UserID),
+			Name:   formatPublicAttendeeName(r.Registrant.Name),
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"event_id":  eventID,
+		"attendees": attendees,
+	})
+}
+
 // creates a new event
 func (h *EventHandler) CreateEvent(c *gin.Context) {
 	var event models.Event

--- a/pkg/mocks/mongo.go
+++ b/pkg/mocks/mongo.go
@@ -114,3 +114,6 @@ func (m *MockMongoStore) GetWaitlistedEventIDsForUser(_ context.Context, _ strin
 func (m *MockMongoStore) PublishDueEvents(_ context.Context, _ time.Time) (int64, error) {
 	return m.PublishedDueCount, m.PublishDueEventsErr
 }
+func (m *MockMongoStore) ListAcceptedRegistrationsForEvent(_ context.Context, _ string) ([]models.RegistrationRequest, error) {
+	return m.Registrations, m.RegistrationsErr
+}


### PR DESCRIPTION
Closes #96 
Adds a backend-only attendees endpoint for events.

This endpoint returns a privacy-safe attendee list and is only accessible to:
- admins with edit access
- users who are already accepted registrants for that event

## Changes
- added `GET /events/:id/attendees` route
- added `GetEventAttendees` handler
- added attendee access check:
  - event edit access OR accepted registration required
- added minimal attendee response shape
  - returns masked display name
  - does not expose email or registration answers
- added Mongo store method to list accepted registrations for an event
- added store interface method for accepted attendee lookup
