### PR TITLE
Make closed events visible to nonmembers

### DIFF
--- a/pkg/db/event.go
+++ b/pkg/db/event.go
@@ -52,15 +52,15 @@ func buildVisibilityFilter(viewer models.EventViewer) bson.M {
 		conditions = append(conditions, bson.M{"admins": viewer.UserID})
 	}
 
-	// Published public events are visible to everyone.
+	// Published or closed public events are visible to everyone.
 	conditions = append(conditions, bson.M{
 		"$and": bson.A{
-			bson.M{"status": models.StatusPublished},
+			bson.M{"status": bson.M{"$in": bson.A{models.StatusPublished, models.StatusClosed}}},
 			bson.M{"visibility": models.VisibilityPublic},
 		},
 	})
 
-	// Published private events require the viewer to meet minimum_visible_role.
+	// Published or closed private events require the viewer to meet minimum_visible_role.
 	privateRoleConditions := bson.A{}
 	if viewer.AccessLevel >= 1 {
 		privateRoleConditions = append(privateRoleConditions, bson.M{"minimum_visible_role": models.RoleMember})
@@ -72,7 +72,7 @@ func buildVisibilityFilter(viewer models.EventViewer) bson.M {
 	if len(privateRoleConditions) > 0 {
 		conditions = append(conditions, bson.M{
 			"$and": bson.A{
-				bson.M{"status": models.StatusPublished},
+				bson.M{"status": bson.M{"$in": bson.A{models.StatusPublished, models.StatusClosed}}},
 				bson.M{"visibility": models.VisibilityPrivate},
 				bson.M{"$or": privateRoleConditions},
 			},


### PR DESCRIPTION
<img width="1758" height="938" alt="image" src="https://github.com/user-attachments/assets/77e8f7c2-c2f5-4032-b786-5fd56308311b" />
<img width="2065" height="905" alt="image" src="https://github.com/user-attachments/assets/bd41abbb-0094-4f3d-a33d-90e458e135aa" />

closed event appears for admins but not a non-logged in user, this PR fixes it