### PR TITLE
Fixing the confusion between pkg/db and pkg/database with renaming

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/SCE-Development/SCEvents/internal/config"
-	"github.com/SCE-Development/SCEvents/pkg/database"
 	"github.com/SCE-Development/SCEvents/pkg/db"
+	"github.com/SCE-Development/SCEvents/pkg/migration"
 	"github.com/SCE-Development/SCEvents/pkg/models"
 )
 
@@ -41,7 +41,7 @@ func main() {
 	log.Printf("migrating collection %q...", entry.Collection)
 
 	coll := db.Database().Collection(entry.Collection)
-	updated, err := database.AutoMigrateDefaults(ctx, coll, entry.Model)
+	updated, err := migration.AutoMigrateDefaults(ctx, coll, entry.Model)
 	if err != nil {
 		log.Fatalf("Failed migrating %s: %v", entry.Collection, err)
 	}

--- a/pkg/migration/migrate.go
+++ b/pkg/migration/migrate.go
@@ -1,4 +1,4 @@
-package database
+package migration
 
 import (
 	"context"

--- a/pkg/migration/migrate_test.go
+++ b/pkg/migration/migrate_test.go
@@ -1,4 +1,4 @@
-package database
+package migration
 
 import (
 	"context"


### PR DESCRIPTION
# PR for #119 

## Problem
In our code, we had 2 pkg folders with similar names, one called db, the other called database. As a result, there was some confusion as to what their purposes were. The db folder is meant for runtime persistence layer (connections, Redis, and Mongo store APIs) and the database folder was contained the migration helper that backfills missing fields from struct default tags.

## Solution
Rename the database folder to migration folder and keep the db folder unchanged. This way, it's more clear on their purposes in the project.