### PR TITLE
Add automatic mongodb field migration runner

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -83,6 +83,14 @@ func main() {
 		startPublisher(ctx, stores)
 	}()
 
+	if cfg.AutoMigrateEnabled {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runAutoMigrations(ctx, cfg.AutoMigrateInterval)
+		}()
+	}
+
 	eventHandler := handlers.NewEventHandler(stores)
 
 	r := gin.Default()

--- a/cmd/server/migrate_runner.go
+++ b/cmd/server/migrate_runner.go
@@ -10,25 +10,25 @@ import (
 	"github.com/SCE-Development/SCEvents/pkg/models"
 )
 
-func runAutoMigrations(ctx context.Context, interval time.Duration) {
-	runOnce := func() {
-		for key, entry := range models.MigrationRegistry {
-			coll := db.Database().Collection(entry.Collection)
+func runMigrationCycle(ctx context.Context) {
+	for key, entry := range models.MigrationRegistry {
+		coll := db.Database().Collection(entry.Collection)
 
-			updated, err := database.AutoMigrateDefaults(ctx, coll, entry.Model)
-			if err != nil {
-				log.Printf("auto-migrate failed for %s (%s): %v", key, entry.Collection, err)
-				continue
-			}
+		updated, err := database.AutoMigrateDefaults(ctx, coll, entry.Model)
+		if err != nil {
+			log.Printf("auto-migrate failed for %s (%s): %v", key, entry.Collection, err)
+			continue
+		}
 
-			if updated > 0 {
-				log.Printf("auto-migrate updated %d fields for %s (%s)", updated, key, entry.Collection)
-			}
+		if updated > 0 {
+			log.Printf("auto-migrate updated %d fields for %s (%s)", updated, key, entry.Collection)
 		}
 	}
+}
 
+func runAutoMigrations(ctx context.Context, interval time.Duration) {
 	// run once at startup
-	runOnce()
+	runMigrationCycle(ctx)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -39,7 +39,7 @@ func runAutoMigrations(ctx context.Context, interval time.Duration) {
 			log.Print("auto-migrate runner stopped")
 			return
 		case <-ticker.C:
-			runOnce()
+			runMigrationCycle(ctx)
 		}
 	}
 }

--- a/cmd/server/migrate_runner.go
+++ b/cmd/server/migrate_runner.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/SCE-Development/SCEvents/pkg/database"
 	"github.com/SCE-Development/SCEvents/pkg/db"
+	"github.com/SCE-Development/SCEvents/pkg/migration"
 	"github.com/SCE-Development/SCEvents/pkg/models"
 )
 
@@ -14,7 +14,7 @@ func runMigrationCycle(ctx context.Context) {
 	for key, entry := range models.MigrationRegistry {
 		coll := db.Database().Collection(entry.Collection)
 
-		updated, err := database.AutoMigrateDefaults(ctx, coll, entry.Model)
+		updated, err := migration.AutoMigrateDefaults(ctx, coll, entry.Model)
 		if err != nil {
 			log.Printf("auto-migrate failed for %s (%s): %v", key, entry.Collection, err)
 			continue

--- a/cmd/server/migrate_runner.go
+++ b/cmd/server/migrate_runner.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/SCE-Development/SCEvents/pkg/database"
+	"github.com/SCE-Development/SCEvents/pkg/db"
+	"github.com/SCE-Development/SCEvents/pkg/models"
+)
+
+func runAutoMigrations(ctx context.Context, interval time.Duration) {
+	runOnce := func() {
+		for key, entry := range models.MigrationRegistry {
+			coll := db.Database().Collection(entry.Collection)
+
+			updated, err := database.AutoMigrateDefaults(ctx, coll, entry.Model)
+			if err != nil {
+				log.Printf("auto-migrate failed for %s (%s): %v", key, entry.Collection, err)
+				continue
+			}
+
+			if updated > 0 {
+				log.Printf("auto-migrate updated %d fields for %s (%s)", updated, key, entry.Collection)
+			}
+		}
+	}
+
+	// run once at startup
+	runOnce()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Print("auto-migrate runner stopped")
+			return
+		case <-ticker.C:
+			runOnce()
+		}
+	}
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,6 +48,8 @@ services:
       - SERVER_PORT=${SERVER_PORT:-8002}
       - CLIENT_URL=${CLIENT_URL:-http://localhost:3000}
       - CLIENT_API_URL=${CLIENT_API_URL:-http://host.docker.internal:8080}
+      - AUTO_MIGRATE_ENABLED=${AUTO_MIGRATE_ENABLED:-true}
+      - AUTO_MIGRATE_INTERVAL_HOURS=${AUTO_MIGRATE_INTERVAL_HOURS:-24}
     volumes:
       - .:/app
       - go-mod-cache:/go/pkg/mod

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,10 @@
 package config
 
-import "os"
+import (
+	"os"
+	"strconv"
+	"time"
+)
 
 type AppConfig struct {
 	MongoURI     string
@@ -11,6 +15,8 @@ type AppConfig struct {
 	ServerPort   string
 	ClientURL    string
 	ClientAPIURL string
+	AutoMigrateEnabled  bool
+	AutoMigrateInterval time.Duration
 }
 
 func Load() AppConfig {
@@ -23,6 +29,8 @@ func Load() AppConfig {
 		ServerPort:   getEnv("SERVER_PORT", "8002"),
 		ClientURL:    getEnv("CLIENT_URL", "http://localhost:3000"),
 		ClientAPIURL: getEnv("CLIENT_API_URL", "http://localhost:8080"),
+		AutoMigrateEnabled:  getEnvBool("AUTO_MIGRATE_ENABLED", true),
+		AutoMigrateInterval: getEnvDurationHours("AUTO_MIGRATE_INTERVAL_HOURS", 24),
 	}
 }
 
@@ -32,4 +40,30 @@ func getEnv(key string, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func getEnvBool(key string, fallback bool) bool {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func getEnvDurationHours(key string, fallbackHours int) time.Duration {
+	value := os.Getenv(key)
+	if value == "" {
+		return time.Duration(fallbackHours) * time.Hour
+	}
+
+	hours, err := strconv.Atoi(value)
+	if err != nil || hours <= 0 {
+		return time.Duration(fallbackHours) * time.Hour
+	}
+	return time.Duration(hours) * time.Hour
 }


### PR DESCRIPTION
Closes #126 
## Changes
- added server-side auto-migration background runner
- runs once on server startup
- continues running on a configurable interval
- iterates through `models.MigrationRegistry`
- calls `database.AutoMigrateDefaults(...)` for each registered collection/model

current default interval is 24 hours unless overridden by env