### PR TITLE
Handle pending auth

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -108,8 +108,8 @@ func OptionalAuth(clientAPIURL string) gin.HandlerFunc {
 
 		userID, role, accessLevel, err := verifyAuthHeader(authHeader, clientAPIURL)
 		if err != nil {
-			// if not success, the token was invalid or the API is down
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Token verification failed"})
+			// if not success, the token was invalid or the user is pending, proceed anonymously
+			c.Next()
 			return
 		}
 

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -257,7 +257,7 @@ func TestOptionalAuth_SetsContextForValidToken(t *testing.T) {
 	}
 }
 
-func TestOptionalAuth_RejectsInvalidToken(t *testing.T) {
+func TestOptionalAuth_IgnoresInvalidToken(t *testing.T) {
 	authHeader := "Bearer invalid-token"
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -273,8 +273,20 @@ func TestOptionalAuth_RejectsInvalidToken(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected status 401, got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if _, ok := response["userID"]; ok && response["userID"] != nil {
+		t.Fatalf("expected no userID, got %v", response["userID"])
+	}
+	if _, ok := response["userRole"]; ok && response["userRole"] != nil {
+		t.Fatalf("expected no userRole, got %v", response["userRole"])
 	}
 }
 


### PR DESCRIPTION
**CONTEXT**
- bug happened in SCEvents where we would indicate that SCEvents was down to a signed-out user, despite it being up --> moreover, signing in would then display the calendar, and then logging out would still display the calendar
- what's the issue?
	- not sure, but we know that the `/api/Auth/verify 403` returned a 403...
	- thus we have two potential reasons
		1. user's auth was somehow set to `PENDING` --> b/c pending is -1, we would return that the API is down
		2. user's auth token was expired --> again, we return that the API is down


**CHANGES**
- update middleware to handle invalid / pending auth states --> basically allow pass if the user is signed out