### PR TITLE
Modifing pipeline checks to only trigger on specific file changes

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -7,7 +7,28 @@ on:
     branches: [main]
 
 jobs:
+  detect-go-ci-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Detect Go CI-impacting changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            should_run:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'vendor/**'
+              - '.github/workflows/go-ci.yml'
+
   verify-and-build:
+    needs: detect-go-ci-changes
+    if: ${{ needs.detect-go-ci-changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -34,3 +55,32 @@ jobs:
 
       - name: Run unit tests
         run: go test ./...
+
+  go-ci-skipped:
+    needs: detect-go-ci-changes
+    if: ${{ needs.detect-go-ci-changes.outputs.should_run != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Go CI skipped by path filter
+        run: echo "No Go CI-impacting files changed. Skipping build and unit tests."
+
+  golang-validation-pipeline-status:
+    needs: [detect-go-ci-changes, verify-and-build, go-ci-skipped]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Go CI outcome
+        run: |
+          if [[ "${{ needs.detect-go-ci-changes.outputs.should_run }}" == "true" ]]; then
+            if [[ "${{ needs.verify-and-build.result }}" != "success" ]]; then
+              echo "Go validation was required and did not pass."
+              exit 1
+            fi
+            echo "Go validation passed."
+          else
+            if [[ "${{ needs.go-ci-skipped.result }}" != "success" ]]; then
+              echo "Go CI skip marker job failed."
+              exit 1
+            fi
+            echo "Go validation intentionally skipped."
+          fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,7 +7,32 @@ on:
     branches: [main]
 
 jobs:
+  detect-integration-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Detect integration-impacting changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            should_run:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'docker-compose.yml'
+              - 'docker-compose.dev.yml'
+              - 'testing/integration/**'
+              - 'testing/Makefile'
+              - 'Makefile'
+              - '.github/workflows/integration.yml'
+
   integration:
+    needs: detect-integration-changes
+    if: ${{ needs.detect-integration-changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -31,3 +56,32 @@ jobs:
       - name: Tear down Compose
         if: always()
         run: make teardown-integration
+
+  integration-skipped:
+    needs: detect-integration-changes
+    if: ${{ needs.detect-integration-changes.outputs.should_run != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Integration skipped by path filter
+        run: echo "No integration-impacting files changed. Skipping integration tests."
+
+  integration-pipeline-status:
+    needs: [detect-integration-changes, integration, integration-skipped]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check integration outcome
+        run: |
+          if [[ "${{ needs.detect-integration-changes.outputs.should_run }}" == "true" ]]; then
+            if [[ "${{ needs.integration.result }}" != "success" ]]; then
+              echo "Integration tests were required and did not pass."
+              exit 1
+            fi
+            echo "Integration tests passed."
+          else
+            if [[ "${{ needs.integration-skipped.result }}" != "success" ]]; then
+              echo "Integration skip marker job failed."
+              exit 1
+            fi
+            echo "Integration tests intentionally skipped."
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,32 @@ on:
     branches: [ "main", "master" ]
 
 jobs:
+  detect-lint-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Detect lint-impacting changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            should_run:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/lint.yml'
+              - '.golangci.yml'
+              - '.golangci.yaml'
+              - '.golangci.toml'
+              - '.golangci.json'
+
   lint:
     name: lint-code
+    needs: detect-lint-changes
+    if: ${{ needs.detect-lint-changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,3 +48,32 @@ jobs:
         with:
           version: v2.11.4
           args: --timeout=5m
+
+  lint-skipped:
+    needs: detect-lint-changes
+    if: ${{ needs.detect-lint-changes.outputs.should_run != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint skipped by path filter
+        run: echo "No lint-impacting files changed. Skipping golangci-lint."
+
+  lint-pipeline-status:
+    needs: [detect-lint-changes, lint, lint-skipped]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check lint outcome
+        run: |
+          if [[ "${{ needs.detect-lint-changes.outputs.should_run }}" == "true" ]]; then
+            if [[ "${{ needs.lint.result }}" != "success" ]]; then
+              echo "Lint was required and did not pass."
+              exit 1
+            fi
+            echo "Lint passed."
+          else
+            if [[ "${{ needs.lint-skipped.result }}" != "success" ]]; then
+              echo "Lint skip marker job failed."
+              exit 1
+            fi
+            echo "Lint intentionally skipped."
+          fi


### PR DESCRIPTION
# PR for #130 

## Problem
Heavy CI (lint, Go build/tests, Docker integration) ran on every PR, even if its simple PR changes like read me's. We should only run CI's on relevant file changes.

## Solution
Add path-based change detection to the SCEvents workflows so those jobs only run when relevant files change, and add always-green status jobs so merge checks still pass when a workflow is intentionally skipped.
